### PR TITLE
0.4.0: removed array wrapping (covered by VSSJson) and updated clients

### DIFF
--- a/api/BuildApi.ts
+++ b/api/BuildApi.ts
@@ -243,7 +243,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
             var apiVersion: string = versioningData.apiVersion;
             var serializationData = {  responseTypeMetadata: BuildInterfaces.TypeInfo.BuildArtifact, responseIsCollection: true };
             
-            this.restClient.getJsonWrappedArray(url, apiVersion, null, serializationData, onResult);
+            this.restClient.getJson(url, apiVersion, null, serializationData, onResult);
         })
         .fail((error) => {
             onResult(error, error.statusCode, null);
@@ -428,7 +428,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
             var apiVersion: string = versioningData.apiVersion;
             var serializationData = {  responseTypeMetadata: BuildInterfaces.TypeInfo.Build, responseIsCollection: true };
             
-            this.restClient.getJsonWrappedArray(url, apiVersion, null, serializationData, onResult);
+            this.restClient.getJson(url, apiVersion, null, serializationData, onResult);
         })
         .fail((error) => {
             onResult(error, error.statusCode, null);
@@ -534,7 +534,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
             var apiVersion: string = versioningData.apiVersion;
             var serializationData = {  responseTypeMetadata: BuildInterfaces.TypeInfo.Change, responseIsCollection: true };
             
-            this.restClient.getJsonWrappedArray(url, apiVersion, null, serializationData, onResult);
+            this.restClient.getJson(url, apiVersion, null, serializationData, onResult);
         })
         .fail((error) => {
             onResult(error, error.statusCode, null);
@@ -593,7 +593,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
             var apiVersion: string = versioningData.apiVersion;
             var serializationData = {  responseTypeMetadata: BuildInterfaces.TypeInfo.BuildController, responseIsCollection: true };
             
-            this.restClient.getJsonWrappedArray(url, apiVersion, null, serializationData, onResult);
+            this.restClient.getJson(url, apiVersion, null, serializationData, onResult);
         })
         .fail((error) => {
             onResult(error, error.statusCode, null);
@@ -740,7 +740,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
             var apiVersion: string = versioningData.apiVersion;
             var serializationData = {  responseTypeMetadata: BuildInterfaces.TypeInfo.DefinitionReference, responseIsCollection: true };
             
-            this.restClient.getJsonWrappedArray(url, apiVersion, null, serializationData, onResult);
+            this.restClient.getJson(url, apiVersion, null, serializationData, onResult);
         })
         .fail((error) => {
             onResult(error, error.statusCode, null);
@@ -813,7 +813,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
             var apiVersion: string = versioningData.apiVersion;
             var serializationData = {  responseTypeMetadata: BuildInterfaces.TypeInfo.Deployment, responseIsCollection: true };
             
-            this.restClient.getJsonWrappedArray(url, apiVersion, null, serializationData, onResult);
+            this.restClient.getJson(url, apiVersion, null, serializationData, onResult);
         })
         .fail((error) => {
             onResult(error, error.statusCode, null);
@@ -887,7 +887,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
             var apiVersion: string = versioningData.apiVersion;
             var serializationData = {  responseTypeMetadata: BuildInterfaces.TypeInfo.BuildLog, responseIsCollection: true };
             
-            this.restClient.getJsonWrappedArray(url, apiVersion, null, serializationData, onResult);
+            this.restClient.getJson(url, apiVersion, null, serializationData, onResult);
         })
         .fail((error) => {
             onResult(error, error.statusCode, null);
@@ -941,7 +941,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
             var apiVersion: string = versioningData.apiVersion;
             var serializationData = {  responseTypeMetadata: BuildInterfaces.TypeInfo.BuildOptionDefinition, responseIsCollection: true };
             
-            this.restClient.getJsonWrappedArray(url, apiVersion, null, serializationData, onResult);
+            this.restClient.getJson(url, apiVersion, null, serializationData, onResult);
         })
         .fail((error) => {
             onResult(error, error.statusCode, null);
@@ -1058,7 +1058,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
             var apiVersion: string = versioningData.apiVersion;
             var serializationData = {  responseTypeMetadata: BuildInterfaces.TypeInfo.AgentPoolQueue, responseIsCollection: true };
             
-            this.restClient.getJsonWrappedArray(url, apiVersion, null, serializationData, onResult);
+            this.restClient.getJson(url, apiVersion, null, serializationData, onResult);
         })
         .fail((error) => {
             onResult(error, error.statusCode, null);
@@ -1089,7 +1089,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
             var apiVersion: string = versioningData.apiVersion;
             var serializationData = {  responseTypeMetadata: BuildInterfaces.TypeInfo.BuildDefinitionRevision, responseIsCollection: true };
             
-            this.restClient.getJsonWrappedArray(url, apiVersion, null, serializationData, onResult);
+            this.restClient.getJson(url, apiVersion, null, serializationData, onResult);
         })
         .fail((error) => {
             onResult(error, error.statusCode, null);
@@ -1206,7 +1206,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
             var apiVersion: string = versioningData.apiVersion;
             var serializationData = {  responseIsCollection: true };
             
-            this.restClient.createJsonWrappedArray(url, apiVersion, tags, null, serializationData, onResult);
+            this.restClient.create(url, apiVersion, tags, null, serializationData, onResult);
         })
         .fail((error) => {
             onResult(error, error.statusCode, null);
@@ -1271,7 +1271,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
             var apiVersion: string = versioningData.apiVersion;
             var serializationData = {  responseIsCollection: true };
             
-            this.restClient.getJsonWrappedArray(url, apiVersion, null, serializationData, onResult);
+            this.restClient.getJson(url, apiVersion, null, serializationData, onResult);
         })
         .fail((error) => {
             onResult(error, error.statusCode, null);
@@ -1297,7 +1297,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
             var apiVersion: string = versioningData.apiVersion;
             var serializationData = {  responseIsCollection: true };
             
-            this.restClient.getJsonWrappedArray(url, apiVersion, null, serializationData, onResult);
+            this.restClient.getJson(url, apiVersion, null, serializationData, onResult);
         })
         .fail((error) => {
             onResult(error, error.statusCode, null);
@@ -1385,7 +1385,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
             var apiVersion: string = versioningData.apiVersion;
             var serializationData = {  responseTypeMetadata: BuildInterfaces.TypeInfo.BuildDefinitionTemplate, responseIsCollection: true };
             
-            this.restClient.getJsonWrappedArray(url, apiVersion, null, serializationData, onResult);
+            this.restClient.getJson(url, apiVersion, null, serializationData, onResult);
         })
         .fail((error) => {
             onResult(error, error.statusCode, null);
@@ -1495,7 +1495,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
             var apiVersion: string = versioningData.apiVersion;
             var serializationData = {  responseTypeMetadata: VSSInterfaces.TypeInfo.ResourceRef, responseIsCollection: true };
             
-            this.restClient.getJsonWrappedArray(url, apiVersion, null, serializationData, onResult);
+            this.restClient.getJson(url, apiVersion, null, serializationData, onResult);
         })
         .fail((error) => {
             onResult(error, error.statusCode, null);
@@ -1534,7 +1534,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
             var apiVersion: string = versioningData.apiVersion;
             var serializationData = {  responseTypeMetadata: VSSInterfaces.TypeInfo.ResourceRef, responseIsCollection: true };
             
-            this.restClient.createJsonWrappedArray(url, apiVersion, commitIds, null, serializationData, onResult);
+            this.restClient.create(url, apiVersion, commitIds, null, serializationData, onResult);
         })
         .fail((error) => {
             onResult(error, error.statusCode, null);

--- a/api/CoreApi.ts
+++ b/api/CoreApi.ts
@@ -152,7 +152,7 @@ export class CoreApi extends basem.ClientApiBase implements ICoreApi {
             var apiVersion: string = versioningData.apiVersion;
             var serializationData = {  responseTypeMetadata: CoreInterfaces.TypeInfo.WebApiConnectedService, responseIsCollection: true };
             
-            this.restClient.getJsonWrappedArray(url, apiVersion, null, serializationData, onResult);
+            this.restClient.getJson(url, apiVersion, null, serializationData, onResult);
         })
         .fail((error) => {
             onResult(error, error.statusCode, null);
@@ -234,7 +234,7 @@ export class CoreApi extends basem.ClientApiBase implements ICoreApi {
             var apiVersion: string = versioningData.apiVersion;
             var serializationData = {  responseTypeMetadata: VSSInterfaces.TypeInfo.IdentityRef, responseIsCollection: true };
             
-            this.restClient.getJsonWrappedArray(url, apiVersion, null, serializationData, onResult);
+            this.restClient.getJson(url, apiVersion, null, serializationData, onResult);
         })
         .fail((error) => {
             onResult(error, error.statusCode, null);
@@ -300,7 +300,7 @@ export class CoreApi extends basem.ClientApiBase implements ICoreApi {
             var apiVersion: string = versioningData.apiVersion;
             var serializationData = {  responseTypeMetadata: VSSInterfaces.TypeInfo.IdentityRef, responseIsCollection: true };
             
-            this.restClient.getJsonWrappedArray(url, apiVersion, null, serializationData, onResult);
+            this.restClient.getJson(url, apiVersion, null, serializationData, onResult);
         })
         .fail((error) => {
             onResult(error, error.statusCode, null);
@@ -362,7 +362,7 @@ export class CoreApi extends basem.ClientApiBase implements ICoreApi {
             var apiVersion: string = versioningData.apiVersion;
             var serializationData = {  responseTypeMetadata: CoreInterfaces.TypeInfo.TeamProjectCollectionReference, responseIsCollection: true };
             
-            this.restClient.getJsonWrappedArray(url, apiVersion, null, serializationData, onResult);
+            this.restClient.getJson(url, apiVersion, null, serializationData, onResult);
         })
         .fail((error) => {
             onResult(error, error.statusCode, null);
@@ -391,7 +391,7 @@ export class CoreApi extends basem.ClientApiBase implements ICoreApi {
             var apiVersion: string = versioningData.apiVersion;
             var serializationData = {  responseTypeMetadata: CoreInterfaces.TypeInfo.TeamProjectReference, responseIsCollection: true };
             
-            this.restClient.getJsonWrappedArray(url, apiVersion, null, serializationData, onResult);
+            this.restClient.getJson(url, apiVersion, null, serializationData, onResult);
         })
         .fail((error) => {
             onResult(error, error.statusCode, null);
@@ -465,7 +465,7 @@ export class CoreApi extends basem.ClientApiBase implements ICoreApi {
             var apiVersion: string = versioningData.apiVersion;
             var serializationData = {  responseTypeMetadata: CoreInterfaces.TypeInfo.TeamProjectReference, responseIsCollection: true };
             
-            this.restClient.getJsonWrappedArray(url, apiVersion, null, serializationData, onResult);
+            this.restClient.getJson(url, apiVersion, null, serializationData, onResult);
         })
         .fail((error) => {
             onResult(error, error.statusCode, null);
@@ -579,7 +579,7 @@ export class CoreApi extends basem.ClientApiBase implements ICoreApi {
             var apiVersion: string = versioningData.apiVersion;
             var serializationData = {  responseTypeMetadata: CoreInterfaces.TypeInfo.Proxy, responseIsCollection: true };
             
-            this.restClient.getJsonWrappedArray(url, apiVersion, null, serializationData, onResult);
+            this.restClient.getJson(url, apiVersion, null, serializationData, onResult);
         })
         .fail((error) => {
             onResult(error, error.statusCode, null);

--- a/api/FileContainerApi.ts
+++ b/api/FileContainerApi.ts
@@ -187,7 +187,7 @@ export class FileContainerApi extends basem.ClientApiBase implements IFileContai
             var apiVersion: string = versioningData.apiVersion;
             var serializationData = {  responseTypeMetadata: FileContainerInterfaces.TypeInfo.FileContainer, responseIsCollection: true };
             
-            this.restClient.getJsonWrappedArray(url, apiVersion, null, serializationData, onResult);
+            this.restClient.getJson(url, apiVersion, null, serializationData, onResult);
         })
         .fail((error) => {
             onResult(error, error.statusCode, null);
@@ -236,7 +236,7 @@ export class FileContainerApi extends basem.ClientApiBase implements IFileContai
             var apiVersion: string = versioningData.apiVersion;
             var serializationData = {  responseTypeMetadata: FileContainerInterfaces.TypeInfo.FileContainerItem, responseIsCollection: true };
             
-            this.restClient.getJsonWrappedArray(url, apiVersion, null, serializationData, onResult);
+            this.restClient.getJson(url, apiVersion, null, serializationData, onResult);
         })
         .fail((error) => {
             onResult(error, error.statusCode, null);

--- a/api/GalleryApi.ts
+++ b/api/GalleryApi.ts
@@ -255,7 +255,7 @@ export class GalleryApi extends basem.ClientApiBase implements IGalleryApi {
             var apiVersion: string = versioningData.apiVersion;
             var serializationData = {  responseIsCollection: true };
             
-            this.restClient.getJsonWrappedArray(url, apiVersion, null, serializationData, onResult);
+            this.restClient.getJson(url, apiVersion, null, serializationData, onResult);
         })
         .fail((error) => {
             onResult(error, error.statusCode, null);

--- a/api/GitApi.ts
+++ b/api/GitApi.ts
@@ -346,7 +346,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
             var apiVersion: string = versioningData.apiVersion;
             var serializationData = {  responseTypeMetadata: GitInterfaces.TypeInfo.GitBranchStats, responseIsCollection: true };
             
-            this.restClient.getJsonWrappedArray(url, apiVersion, null, serializationData, onResult);
+            this.restClient.getJson(url, apiVersion, null, serializationData, onResult);
         })
         .fail((error) => {
             onResult(error, error.statusCode, null);
@@ -503,7 +503,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
             var apiVersion: string = versioningData.apiVersion;
             var serializationData = {  responseTypeMetadata: GitInterfaces.TypeInfo.GitCommitRef, responseIsCollection: true };
             
-            this.restClient.getJsonWrappedArray(url, apiVersion, null, serializationData, onResult);
+            this.restClient.getJson(url, apiVersion, null, serializationData, onResult);
         })
         .fail((error) => {
             onResult(error, error.statusCode, null);
@@ -549,7 +549,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
             var apiVersion: string = versioningData.apiVersion;
             var serializationData = {  responseTypeMetadata: GitInterfaces.TypeInfo.GitCommitRef, responseIsCollection: true };
             
-            this.restClient.getJsonWrappedArray(url, apiVersion, null, serializationData, onResult);
+            this.restClient.getJson(url, apiVersion, null, serializationData, onResult);
         })
         .fail((error) => {
             onResult(error, error.statusCode, null);
@@ -756,7 +756,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
             var apiVersion: string = versioningData.apiVersion;
             var serializationData = {  responseTypeMetadata: GitInterfaces.TypeInfo.GitItem, responseIsCollection: true };
             
-            this.restClient.getJsonWrappedArray(url, apiVersion, null, serializationData, onResult);
+            this.restClient.getJson(url, apiVersion, null, serializationData, onResult);
         })
         .fail((error) => {
             onResult(error, error.statusCode, null);
@@ -974,7 +974,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
             var apiVersion: string = versioningData.apiVersion;
             var serializationData = { requestTypeMetadata: VSSInterfaces.TypeInfo.IdentityRef, responseTypeMetadata: GitInterfaces.TypeInfo.IdentityRefWithVote, responseIsCollection: true };
             
-            this.restClient.createJsonWrappedArray(url, apiVersion, reviewers, null, serializationData, onResult);
+            this.restClient.create(url, apiVersion, reviewers, null, serializationData, onResult);
         })
         .fail((error) => {
             onResult(error, error.statusCode, null);
@@ -1082,7 +1082,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
             var apiVersion: string = versioningData.apiVersion;
             var serializationData = {  responseTypeMetadata: GitInterfaces.TypeInfo.IdentityRefWithVote, responseIsCollection: true };
             
-            this.restClient.getJsonWrappedArray(url, apiVersion, null, serializationData, onResult);
+            this.restClient.getJson(url, apiVersion, null, serializationData, onResult);
         })
         .fail((error) => {
             onResult(error, error.statusCode, null);
@@ -1125,7 +1125,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
             var apiVersion: string = versioningData.apiVersion;
             var serializationData = {  responseTypeMetadata: GitInterfaces.TypeInfo.GitPullRequest, responseIsCollection: true };
             
-            this.restClient.getJsonWrappedArray(url, apiVersion, null, serializationData, onResult);
+            this.restClient.getJson(url, apiVersion, null, serializationData, onResult);
         })
         .fail((error) => {
             onResult(error, error.statusCode, null);
@@ -1250,7 +1250,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
             var apiVersion: string = versioningData.apiVersion;
             var serializationData = {  responseTypeMetadata: GitInterfaces.TypeInfo.GitPullRequest, responseIsCollection: true };
             
-            this.restClient.getJsonWrappedArray(url, apiVersion, null, serializationData, onResult);
+            this.restClient.getJson(url, apiVersion, null, serializationData, onResult);
         })
         .fail((error) => {
             onResult(error, error.statusCode, null);
@@ -1329,7 +1329,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
             var apiVersion: string = versioningData.apiVersion;
             var serializationData = {  responseTypeMetadata: GitInterfaces.TypeInfo.AssociatedWorkItem, responseIsCollection: true };
             
-            this.restClient.getJsonWrappedArray(url, apiVersion, null, serializationData, onResult);
+            this.restClient.getJson(url, apiVersion, null, serializationData, onResult);
         })
         .fail((error) => {
             onResult(error, error.statusCode, null);
@@ -1448,7 +1448,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
             var apiVersion: string = versioningData.apiVersion;
             var serializationData = {  responseTypeMetadata: GitInterfaces.TypeInfo.GitPush, responseIsCollection: true };
             
-            this.restClient.getJsonWrappedArray(url, apiVersion, null, serializationData, onResult);
+            this.restClient.getJson(url, apiVersion, null, serializationData, onResult);
         })
         .fail((error) => {
             onResult(error, error.statusCode, null);
@@ -1488,7 +1488,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
             var apiVersion: string = versioningData.apiVersion;
             var serializationData = {  responseTypeMetadata: GitInterfaces.TypeInfo.GitRef, responseIsCollection: true };
             
-            this.restClient.getJsonWrappedArray(url, apiVersion, null, serializationData, onResult);
+            this.restClient.getJson(url, apiVersion, null, serializationData, onResult);
         })
         .fail((error) => {
             onResult(error, error.statusCode, null);
@@ -1527,7 +1527,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
             var apiVersion: string = versioningData.apiVersion;
             var serializationData = { requestTypeMetadata: GitInterfaces.TypeInfo.GitRefUpdate, responseTypeMetadata: GitInterfaces.TypeInfo.GitRefUpdateResult, responseIsCollection: true };
             
-            this.restClient.createJsonWrappedArray(url, apiVersion, refUpdates, null, serializationData, onResult);
+            this.restClient.create(url, apiVersion, refUpdates, null, serializationData, onResult);
         })
         .fail((error) => {
             onResult(error, error.statusCode, null);
@@ -1622,7 +1622,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
             var apiVersion: string = versioningData.apiVersion;
             var serializationData = {  responseTypeMetadata: GitInterfaces.TypeInfo.GitRepository, responseIsCollection: true };
             
-            this.restClient.getJsonWrappedArray(url, apiVersion, null, serializationData, onResult);
+            this.restClient.getJson(url, apiVersion, null, serializationData, onResult);
         })
         .fail((error) => {
             onResult(error, error.statusCode, null);

--- a/api/RestClient.ts
+++ b/api/RestClient.ts
@@ -101,20 +101,6 @@ export class RestClient implements ifm.IRestClient {
         this._getJson('GET', url, apiVersion, customHeaders, serializationData, onResult);
     }
 
-    getJsonWrappedArray(url: string, apiVersion: string, customHeaders: ifm.IHeaders, serializationData: Serialization.SerializationData, onResult: (err: any, statusCode: number, obj: any) => void): void {
-        this.getJson(url, apiVersion, customHeaders, serializationData, (err: any, statusCode: number, obj: any) => {
-            if (err) {
-                onResult(err, statusCode, null);
-            } else {
-                if (obj['value'] instanceof Array) {
-                    onResult(null, statusCode, obj['value']);
-                } else {
-                    onResult(null, statusCode, obj);
-                }
-            }
-        });
-    }
-
     options(url: string, onResult: (err: any, statusCode: number, obj: any) => void): void {
         this._getJson('OPTIONS', url, "", null, null, onResult);
     }
@@ -127,16 +113,8 @@ export class RestClient implements ifm.IRestClient {
         this._sendJson('POST', url, apiVersion, resources, customHeaders, serializationData, onResult);
     }
 
-    createJsonWrappedArray(url: string, apiVersion: string, resources: any[], customHeaders: ifm.IHeaders, serializationData: Serialization.SerializationData, onResult: (err: any, statusCode: number, resources: any[]) => void): void {
-        this._sendWrappedJson('POST', url, apiVersion, resources, customHeaders, serializationData, onResult);
-    }
-
     update(url: string, apiVersion: string, resources: any, customHeaders: ifm.IHeaders, serializationData: Serialization.SerializationData, onResult: (err: any, statusCode: number, obj: any) => void): void {
         this._sendJson('PATCH', url, apiVersion, resources, customHeaders, serializationData, onResult);
-    }
-
-    updateJsonWrappedArray(url: string, apiVersion: string, resources: any[], customHeaders: ifm.IHeaders, serializationData: Serialization.SerializationData, onResult: (err: any, statusCode: number, resources: any[]) => void): void {
-        this._sendWrappedJson('PATCH', url, apiVersion, resources, customHeaders, serializationData, onResult);
     }
 
     uploadFile(verb: string, url: string, apiVersion: string, filePath: string, customHeaders: ifm.IHeaders, serializationData: Serialization.SerializationData, onResult: (err: any, statusCode: number, obj: any) => void): void {
@@ -172,22 +150,6 @@ export class RestClient implements ifm.IRestClient {
 
     replace(url: string, apiVersion: string, resources: any, customHeaders: ifm.IHeaders, serializationData: Serialization.SerializationData, onResult: (err: any, statusCode: number, obj: any) => void): void {
         this._sendJson('PUT', url, apiVersion, resources, customHeaders, serializationData, onResult);
-    }
-
-    _sendWrappedJson(verb: string, url: string, apiVersion: string, resources: any[], customHeaders: ifm.IHeaders, serializationData: Serialization.SerializationData, onResult: (err: any, statusCode: number, resources: any[]) => void): void {
-        var wrapped = <Serialization.IWebApiArrayResult>{
-            count: resources.length,
-            value: resources
-        }
-
-        this._sendJson(verb, url, apiVersion, wrapped, customHeaders, serializationData, (err: any, statusCode: number, obj: any) => {
-            if (err) {
-                onResult(err, statusCode, null);
-            } else {
-                var val = obj ? obj.value : obj;
-                onResult(null, statusCode, val);
-            }
-        });
     }
 
     _getJson(verb: string, url: string, apiVersion: string, customHeaders: ifm.IHeaders, serializationData: Serialization.SerializationData, onResult: (err: any, statusCode: number, obj: any) => void): void {

--- a/api/TaskApi.ts
+++ b/api/TaskApi.ts
@@ -95,7 +95,7 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
             var apiVersion: string = versioningData.apiVersion;
             var serializationData = {  responseTypeMetadata: TaskAgentInterfaces.TypeInfo.TaskAttachment, responseIsCollection: true };
             
-            this.restClient.getJsonWrappedArray(url, apiVersion, null, serializationData, onResult);
+            this.restClient.getJson(url, apiVersion, null, serializationData, onResult);
         })
         .fail((error) => {
             onResult(error, error.statusCode, null);
@@ -192,7 +192,7 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
             var apiVersion: string = versioningData.apiVersion;
             var serializationData = {  responseTypeMetadata: TaskAgentInterfaces.TypeInfo.TaskAttachment, responseIsCollection: true };
             
-            this.restClient.getJsonWrappedArray(url, apiVersion, null, serializationData, onResult);
+            this.restClient.getJson(url, apiVersion, null, serializationData, onResult);
         })
         .fail((error) => {
             onResult(error, error.statusCode, null);
@@ -385,7 +385,7 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
             var apiVersion: string = versioningData.apiVersion;
             var serializationData = {  responseIsCollection: true };
             
-            this.restClient.getJsonWrappedArray(url, apiVersion, null, serializationData, onResult);
+            this.restClient.getJson(url, apiVersion, null, serializationData, onResult);
         })
         .fail((error) => {
             onResult(error, error.statusCode, null);
@@ -417,7 +417,7 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
             var apiVersion: string = versioningData.apiVersion;
             var serializationData = {  responseTypeMetadata: TaskAgentInterfaces.TypeInfo.TaskLog, responseIsCollection: true };
             
-            this.restClient.getJsonWrappedArray(url, apiVersion, null, serializationData, onResult);
+            this.restClient.getJson(url, apiVersion, null, serializationData, onResult);
         })
         .fail((error) => {
             onResult(error, error.statusCode, null);
@@ -490,7 +490,7 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
             var apiVersion: string = versioningData.apiVersion;
             var serializationData = {  responseTypeMetadata: TaskAgentInterfaces.TypeInfo.TimelineRecord, responseIsCollection: true };
             
-            this.restClient.getJsonWrappedArray(url, apiVersion, null, serializationData, onResult);
+            this.restClient.getJson(url, apiVersion, null, serializationData, onResult);
         })
         .fail((error) => {
             onResult(error, error.statusCode, null);
@@ -672,7 +672,7 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
             var apiVersion: string = versioningData.apiVersion;
             var serializationData = {  responseTypeMetadata: TaskAgentInterfaces.TypeInfo.Timeline, responseIsCollection: true };
             
-            this.restClient.getJsonWrappedArray(url, apiVersion, null, serializationData, onResult);
+            this.restClient.getJson(url, apiVersion, null, serializationData, onResult);
         })
         .fail((error) => {
             onResult(error, error.statusCode, null);

--- a/api/TestApi.ts
+++ b/api/TestApi.ts
@@ -26,7 +26,7 @@ export interface ITestApi extends basem.ClientApiBase {
     createTestRunAttachment(attachmentRequestModel: TestInterfaces.TestAttachmentRequestModel, project: string, runId: number, onResult: (err: any, statusCode: number, Attachment: TestInterfaces.TestAttachmentReference) => void): void;
     getBuildCodeCoverage(project: string, buildId: number, flags: number, onResult: (err: any, statusCode: number, CodeCoverage: TestInterfaces.BuildCoverage[]) => void): void;
     getCodeCoverageSummary(project: string, buildId: number, deltaBuildId: number, onResult: (err: any, statusCode: number, CodeCoverage: TestInterfaces.CodeCoverageSummary) => void): void;
-    updateCodeCoverageSummary(coverageData: TestInterfaces.CodeCoverageData, project: string, build: number, onResult: (err: any, statusCode: number) => void): void;
+    updateCodeCoverageSummary(coverageData: TestInterfaces.CodeCoverageData, project: string, buildId: number, onResult: (err: any, statusCode: number) => void): void;
     getTestRunCodeCoverage(project: string, runId: number, flags: number, onResult: (err: any, statusCode: number, CodeCoverage: TestInterfaces.TestRunCoverage[]) => void): void;
     addCustomFields(newFields: TestInterfaces.CustomTestFieldDefinition[], project: string, onResult: (err: any, statusCode: number, ExtensionFields: TestInterfaces.CustomTestFieldDefinition[]) => void): void;
     queryCustomFields(project: string, scopeFilter: TestInterfaces.CustomTestFieldScope, onResult: (err: any, statusCode: number, ExtensionFields: TestInterfaces.CustomTestFieldDefinition[]) => void): void;
@@ -38,6 +38,8 @@ export interface ITestApi extends basem.ClientApiBase {
     getPoint(project: string, planId: number, suiteId: number, pointIds: number, witFields: string, onResult: (err: any, statusCode: number, Point: TestInterfaces.TestPoint) => void): void;
     getPoints(project: string, planId: number, suiteId: number, witFields: string, configurationId: string, testCaseId: string, testPointIds: string, includePointDetails: boolean, skip: number, top: number, onResult: (err: any, statusCode: number, Points: TestInterfaces.TestPoint[]) => void): void;
     updateTestPoints(pointUpdateModel: TestInterfaces.PointUpdateModel, project: string, planId: number, suiteId: number, pointIds: string, onResult: (err: any, statusCode: number, Point: TestInterfaces.TestPoint[]) => void): void;
+    queryReportForBuild(build: TestInterfaces.BuildReference, project: string, sourceWorkflow: string, includeFailureDetails: boolean, buildToCompare: TestInterfaces.BuildReference, onResult: (err: any, statusCode: number, ReportForBuild: TestInterfaces.TestReport) => void): void;
+    queryReportForTestRun(project: string, testRunId: number, includeFailureDetails: boolean, onResult: (err: any, statusCode: number, ReportForBuild: TestInterfaces.TestReport) => void): void;
     getTestIteration(project: string, runId: number, testCaseResultId: number, iterationId: number, includeActionResults: boolean, onResult: (err: any, statusCode: number, Result: TestInterfaces.TestIterationDetailsModel) => void): void;
     getTestIterations(project: string, runId: number, testCaseResultId: number, includeActionResults: boolean, onResult: (err: any, statusCode: number, Results: TestInterfaces.TestIterationDetailsModel[]) => void): void;
     addTestResultsToTestRun(resultCreateModels: TestInterfaces.TestResultCreateModel[], project: string, runId: number, onResult: (err: any, statusCode: number, Results: TestInterfaces.TestCaseResult[]) => void): void;
@@ -65,6 +67,8 @@ export interface ITestApi extends basem.ClientApiBase {
     getTestSuitesForPlan(project: string, planId: number, includeSuites: boolean, skip: number, top: number, onResult: (err: any, statusCode: number, Suites: TestInterfaces.TestSuite[]) => void): void;
     updateTestSuite(suiteUpdateModel: TestInterfaces.SuiteUpdateModel, project: string, planId: number, suiteId: number, onResult: (err: any, statusCode: number, Suite: TestInterfaces.TestSuite) => void): void;
     getSuitesByTestCaseId(testCaseId: number, onResult: (err: any, statusCode: number, Suites: TestInterfaces.TestSuite[]) => void): void;
+    queryFailureDetailsForBuild(build: TestInterfaces.BuildReference, project: string, sourceWorkflow: string, buildToCompare: TestInterfaces.BuildReference, onResult: (err: any, statusCode: number, TestFailure: TestInterfaces.TestFailures) => void): void;
+    queryFailureDetailsForTestRun(project: string, testRunId: number, onResult: (err: any, statusCode: number, TestFailure: TestInterfaces.TestFailures) => void): void;
     createTestSettings(testSettings: TestInterfaces.TestSettings, project: string, onResult: (err: any, statusCode: number, TestSetting: number) => void): void;
     deleteTestSettings(project: string, testSettingsId: number, onResult: (err: any, statusCode: number) => void): void;
     getTestSettingsById(project: string, testSettingsId: number, onResult: (err: any, statusCode: number, TestSetting: TestInterfaces.TestSettings) => void): void;
@@ -87,6 +91,8 @@ export interface IQTestApi extends basem.QClientApiBase {
     getPoint(project: string, planId: number, suiteId: number, pointIds: number,  witFields?: string): Q.Promise<TestInterfaces.TestPoint>;
     getPoints(project: string, planId: number, suiteId: number, witFields?: string, configurationId?: string, testCaseId?: string, testPointIds?: string, includePointDetails?: boolean, skip?: number,  top?: number): Q.Promise<TestInterfaces.TestPoint[]>;
     updateTestPoints(pointUpdateModel: TestInterfaces.PointUpdateModel, project: string, planId: number, suiteId: number,  pointIds: string): Q.Promise<TestInterfaces.TestPoint[]>;
+    queryReportForBuild(build: TestInterfaces.BuildReference, project: string, sourceWorkflow: string, includeFailureDetails: boolean,  buildToCompare: TestInterfaces.BuildReference): Q.Promise<TestInterfaces.TestReport>;
+    queryReportForTestRun(project: string, testRunId: number,  includeFailureDetails: boolean): Q.Promise<TestInterfaces.TestReport>;
     getTestIteration(project: string, runId: number, testCaseResultId: number, iterationId: number,  includeActionResults?: boolean): Q.Promise<TestInterfaces.TestIterationDetailsModel>;
     getTestIterations(project: string, runId: number, testCaseResultId: number,  includeActionResults?: boolean): Q.Promise<TestInterfaces.TestIterationDetailsModel[]>;
     addTestResultsToTestRun(resultCreateModels: TestInterfaces.TestResultCreateModel[], project: string,  runId: number): Q.Promise<TestInterfaces.TestCaseResult[]>;
@@ -111,6 +117,8 @@ export interface IQTestApi extends basem.QClientApiBase {
     getTestSuitesForPlan(project: string, planId: number, includeSuites?: boolean, skip?: number,  top?: number): Q.Promise<TestInterfaces.TestSuite[]>;
     updateTestSuite(suiteUpdateModel: TestInterfaces.SuiteUpdateModel, project: string, planId: number,  suiteId: number): Q.Promise<TestInterfaces.TestSuite>;
     getSuitesByTestCaseId( testCaseId: number): Q.Promise<TestInterfaces.TestSuite[]>;
+    queryFailureDetailsForBuild(build: TestInterfaces.BuildReference, project: string, sourceWorkflow: string,  buildToCompare: TestInterfaces.BuildReference): Q.Promise<TestInterfaces.TestFailures>;
+    queryFailureDetailsForTestRun(project: string,  testRunId: number): Q.Promise<TestInterfaces.TestFailures>;
     createTestSettings(testSettings: TestInterfaces.TestSettings,  project: string): Q.Promise<number>;
     getTestSettingsById(project: string,  testSettingsId: number): Q.Promise<TestInterfaces.TestSettings>;
 }
@@ -214,7 +222,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
             var apiVersion: string = versioningData.apiVersion;
             var serializationData = {  responseTypeMetadata: TestInterfaces.TypeInfo.BuildCoverage, responseIsCollection: true };
             
-            this.restClient.getJsonWrappedArray(url, apiVersion, null, serializationData, onResult);
+            this.restClient.getJson(url, apiVersion, null, serializationData, onResult);
         })
         .fail((error) => {
             onResult(error, error.statusCode, null);
@@ -257,17 +265,17 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
     }
 
     /**
-     * http://(tfsserver):8080/tfs/DefaultCollection/_apis/test/CodeCoverage?build=10 Request: Json of code coverage summary
+     * http://(tfsserver):8080/tfs/DefaultCollection/_apis/test/CodeCoverage?buildId=10 Request: Json of code coverage summary
      * 
      * @param {TestInterfaces.CodeCoverageData} coverageData
      * @param {string} project - Project ID or project name
-     * @param {number} build
+     * @param {number} buildId
      * @param onResult callback function
      */
     public updateCodeCoverageSummary(
         coverageData: TestInterfaces.CodeCoverageData,
         project: string,
-        build: number,
+        buildId: number,
         onResult: (err: any, statusCode: number) => void
         ): void {
 
@@ -276,7 +284,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
         };
 
         var queryValues: any = {
-            build: build,
+            buildId: buildId,
         };
         
         this.vsoClient.getVersioningData("3.0-preview.1", "Test", "77560e8a-4e8c-4d59-894e-a5f264c24444", routeValues, queryValues)
@@ -320,7 +328,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
             var apiVersion: string = versioningData.apiVersion;
             var serializationData = {  responseTypeMetadata: TestInterfaces.TypeInfo.TestRunCoverage, responseIsCollection: true };
             
-            this.restClient.getJsonWrappedArray(url, apiVersion, null, serializationData, onResult);
+            this.restClient.getJson(url, apiVersion, null, serializationData, onResult);
         })
         .fail((error) => {
             onResult(error, error.statusCode, null);
@@ -348,7 +356,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
             var apiVersion: string = versioningData.apiVersion;
             var serializationData = { requestTypeMetadata: TestInterfaces.TypeInfo.CustomTestFieldDefinition, responseTypeMetadata: TestInterfaces.TypeInfo.CustomTestFieldDefinition, responseIsCollection: true };
             
-            this.restClient.createJsonWrappedArray(url, apiVersion, newFields, null, serializationData, onResult);
+            this.restClient.create(url, apiVersion, newFields, null, serializationData, onResult);
         })
         .fail((error) => {
             onResult(error, error.statusCode, null);
@@ -380,7 +388,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
             var apiVersion: string = versioningData.apiVersion;
             var serializationData = {  responseTypeMetadata: TestInterfaces.TypeInfo.CustomTestFieldDefinition, responseIsCollection: true };
             
-            this.restClient.getJsonWrappedArray(url, apiVersion, null, serializationData, onResult);
+            this.restClient.getJson(url, apiVersion, null, serializationData, onResult);
         })
         .fail((error) => {
             onResult(error, error.statusCode, null);
@@ -409,7 +417,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
             var apiVersion: string = versioningData.apiVersion;
             var serializationData = {  responseTypeMetadata: TestInterfaces.TypeInfo.TestMessageLogDetails, responseIsCollection: true };
             
-            this.restClient.getJsonWrappedArray(url, apiVersion, null, serializationData, onResult);
+            this.restClient.getJson(url, apiVersion, null, serializationData, onResult);
         })
         .fail((error) => {
             onResult(error, error.statusCode, null);
@@ -510,7 +518,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
             var apiVersion: string = versioningData.apiVersion;
             var serializationData = {  responseTypeMetadata: TestInterfaces.TypeInfo.TestPlan, responseIsCollection: true };
             
-            this.restClient.getJsonWrappedArray(url, apiVersion, null, serializationData, onResult);
+            this.restClient.getJson(url, apiVersion, null, serializationData, onResult);
         })
         .fail((error) => {
             onResult(error, error.statusCode, null);
@@ -638,7 +646,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
             var apiVersion: string = versioningData.apiVersion;
             var serializationData = {  responseTypeMetadata: TestInterfaces.TypeInfo.TestPoint, responseIsCollection: true };
             
-            this.restClient.getJsonWrappedArray(url, apiVersion, null, serializationData, onResult);
+            this.restClient.getJson(url, apiVersion, null, serializationData, onResult);
         })
         .fail((error) => {
             onResult(error, error.statusCode, null);
@@ -676,6 +684,81 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
             var serializationData = { requestTypeMetadata: TestInterfaces.TypeInfo.PointUpdateModel, responseTypeMetadata: TestInterfaces.TypeInfo.TestPoint, responseIsCollection: true };
             
             this.restClient.update(url, apiVersion, pointUpdateModel, null, serializationData, onResult);
+        })
+        .fail((error) => {
+            onResult(error, error.statusCode, null);
+        });
+    }
+
+    /**
+     * @param {TestInterfaces.BuildReference} build
+     * @param {string} project - Project ID or project name
+     * @param {string} sourceWorkflow
+     * @param {boolean} includeFailureDetails
+     * @param {TestInterfaces.BuildReference} buildToCompare
+     * @param onResult callback function with the resulting TestInterfaces.TestReport
+     */
+    public queryReportForBuild(
+        build: TestInterfaces.BuildReference,
+        project: string,
+        sourceWorkflow: string,
+        includeFailureDetails: boolean,
+        buildToCompare: TestInterfaces.BuildReference,
+        onResult: (err: any, statusCode: number, ReportForBuild: TestInterfaces.TestReport) => void
+        ): void {
+
+        var routeValues: any = {
+            project: project
+        };
+
+        var queryValues: any = {
+            sourceWorkflow: sourceWorkflow,
+            includeFailureDetails: includeFailureDetails,
+            buildToCompare: buildToCompare,
+        };
+        
+        this.vsoClient.getVersioningData("3.0-preview.1", "Test", "000ef77b-fea2-498d-a10d-ad1a037f559f", routeValues, queryValues)
+        .then((versioningData: vsom.ClientVersioningData) => {
+            var url: string = versioningData.requestUrl;
+            var apiVersion: string = versioningData.apiVersion;
+            var serializationData = { requestTypeMetadata: TestInterfaces.TypeInfo.BuildReference, responseTypeMetadata: TestInterfaces.TypeInfo.TestReport, responseIsCollection: false };
+            
+            this.restClient.getJson(url, apiVersion, null, serializationData, onResult);
+        })
+        .fail((error) => {
+            onResult(error, error.statusCode, null);
+        });
+    }
+
+    /**
+     * @param {string} project - Project ID or project name
+     * @param {number} testRunId
+     * @param {boolean} includeFailureDetails
+     * @param onResult callback function with the resulting TestInterfaces.TestReport
+     */
+    public queryReportForTestRun(
+        project: string,
+        testRunId: number,
+        includeFailureDetails: boolean,
+        onResult: (err: any, statusCode: number, ReportForBuild: TestInterfaces.TestReport) => void
+        ): void {
+
+        var routeValues: any = {
+            project: project
+        };
+
+        var queryValues: any = {
+            testRunId: testRunId,
+            includeFailureDetails: includeFailureDetails,
+        };
+        
+        this.vsoClient.getVersioningData("3.0-preview.1", "Test", "000ef77b-fea2-498d-a10d-ad1a037f559f", routeValues, queryValues)
+        .then((versioningData: vsom.ClientVersioningData) => {
+            var url: string = versioningData.requestUrl;
+            var apiVersion: string = versioningData.apiVersion;
+            var serializationData = {  responseTypeMetadata: TestInterfaces.TypeInfo.TestReport, responseIsCollection: false };
+            
+            this.restClient.getJson(url, apiVersion, null, serializationData, onResult);
         })
         .fail((error) => {
             onResult(error, error.statusCode, null);
@@ -754,7 +837,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
             var apiVersion: string = versioningData.apiVersion;
             var serializationData = {  responseTypeMetadata: TestInterfaces.TypeInfo.TestIterationDetailsModel, responseIsCollection: true };
             
-            this.restClient.getJsonWrappedArray(url, apiVersion, null, serializationData, onResult);
+            this.restClient.getJson(url, apiVersion, null, serializationData, onResult);
         })
         .fail((error) => {
             onResult(error, error.statusCode, null);
@@ -785,7 +868,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
             var apiVersion: string = versioningData.apiVersion;
             var serializationData = { requestTypeMetadata: TestInterfaces.TypeInfo.TestResultCreateModel, responseTypeMetadata: TestInterfaces.TypeInfo.TestCaseResult, responseIsCollection: true };
             
-            this.restClient.createJsonWrappedArray(url, apiVersion, resultCreateModels, null, serializationData, onResult);
+            this.restClient.create(url, apiVersion, resultCreateModels, null, serializationData, onResult);
         })
         .fail((error) => {
             onResult(error, error.statusCode, null);
@@ -895,7 +978,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
             var apiVersion: string = versioningData.apiVersion;
             var serializationData = {  responseTypeMetadata: TestInterfaces.TypeInfo.TestCaseResult, responseIsCollection: true };
             
-            this.restClient.getJsonWrappedArray(url, apiVersion, null, serializationData, onResult);
+            this.restClient.getJson(url, apiVersion, null, serializationData, onResult);
         })
         .fail((error) => {
             onResult(error, error.statusCode, null);
@@ -926,7 +1009,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
             var apiVersion: string = versioningData.apiVersion;
             var serializationData = { requestTypeMetadata: TestInterfaces.TypeInfo.TestCaseResultUpdateModel, responseTypeMetadata: TestInterfaces.TypeInfo.TestCaseResult, responseIsCollection: true };
             
-            this.restClient.updateJsonWrappedArray(url, apiVersion, resultUpdateModels, null, serializationData, onResult);
+            this.restClient.update(url, apiVersion, resultUpdateModels, null, serializationData, onResult);
         })
         .fail((error) => {
             onResult(error, error.statusCode, null);
@@ -964,7 +1047,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
             var apiVersion: string = versioningData.apiVersion;
             var serializationData = {  responseTypeMetadata: TestInterfaces.TypeInfo.TestActionResultModel, responseIsCollection: true };
             
-            this.restClient.getJsonWrappedArray(url, apiVersion, null, serializationData, onResult);
+            this.restClient.getJson(url, apiVersion, null, serializationData, onResult);
         })
         .fail((error) => {
             onResult(error, error.statusCode, null);
@@ -1005,7 +1088,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
             var apiVersion: string = versioningData.apiVersion;
             var serializationData = {  responseTypeMetadata: TestInterfaces.TypeInfo.TestResultParameterModel, responseIsCollection: true };
             
-            this.restClient.getJsonWrappedArray(url, apiVersion, null, serializationData, onResult);
+            this.restClient.getJson(url, apiVersion, null, serializationData, onResult);
         })
         .fail((error) => {
             onResult(error, error.statusCode, null);
@@ -1256,7 +1339,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
             var apiVersion: string = versioningData.apiVersion;
             var serializationData = {  responseTypeMetadata: TestInterfaces.TypeInfo.TestRun, responseIsCollection: true };
             
-            this.restClient.getJsonWrappedArray(url, apiVersion, null, serializationData, onResult);
+            this.restClient.getJson(url, apiVersion, null, serializationData, onResult);
         })
         .fail((error) => {
             onResult(error, error.statusCode, null);
@@ -1322,7 +1405,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
             var apiVersion: string = versioningData.apiVersion;
             var serializationData = {  responseTypeMetadata: TestInterfaces.TypeInfo.SuiteTestCase, responseIsCollection: true };
             
-            this.restClient.createJsonWrappedArray(url, apiVersion, null, null, serializationData, onResult);
+            this.restClient.create(url, apiVersion, null, null, serializationData, onResult);
         })
         .fail((error) => {
             onResult(error, error.statusCode, null);
@@ -1389,7 +1472,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
             var apiVersion: string = versioningData.apiVersion;
             var serializationData = {  responseTypeMetadata: TestInterfaces.TypeInfo.SuiteTestCase, responseIsCollection: true };
             
-            this.restClient.getJsonWrappedArray(url, apiVersion, null, serializationData, onResult);
+            this.restClient.getJson(url, apiVersion, null, serializationData, onResult);
         })
         .fail((error) => {
             onResult(error, error.statusCode, null);
@@ -1569,7 +1652,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
             var apiVersion: string = versioningData.apiVersion;
             var serializationData = {  responseTypeMetadata: TestInterfaces.TypeInfo.TestSuite, responseIsCollection: true };
             
-            this.restClient.getJsonWrappedArray(url, apiVersion, null, serializationData, onResult);
+            this.restClient.getJson(url, apiVersion, null, serializationData, onResult);
         })
         .fail((error) => {
             onResult(error, error.statusCode, null);
@@ -1632,7 +1715,76 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
             var apiVersion: string = versioningData.apiVersion;
             var serializationData = {  responseTypeMetadata: TestInterfaces.TypeInfo.TestSuite, responseIsCollection: true };
             
-            this.restClient.getJsonWrappedArray(url, apiVersion, null, serializationData, onResult);
+            this.restClient.getJson(url, apiVersion, null, serializationData, onResult);
+        })
+        .fail((error) => {
+            onResult(error, error.statusCode, null);
+        });
+    }
+
+    /**
+     * @param {TestInterfaces.BuildReference} build
+     * @param {string} project - Project ID or project name
+     * @param {string} sourceWorkflow
+     * @param {TestInterfaces.BuildReference} buildToCompare
+     * @param onResult callback function with the resulting TestInterfaces.TestFailures
+     */
+    public queryFailureDetailsForBuild(
+        build: TestInterfaces.BuildReference,
+        project: string,
+        sourceWorkflow: string,
+        buildToCompare: TestInterfaces.BuildReference,
+        onResult: (err: any, statusCode: number, TestFailure: TestInterfaces.TestFailures) => void
+        ): void {
+
+        var routeValues: any = {
+            project: project
+        };
+
+        var queryValues: any = {
+            sourceWorkflow: sourceWorkflow,
+            buildToCompare: buildToCompare,
+        };
+        
+        this.vsoClient.getVersioningData("3.0-preview.1", "Test", "aa4e770d-13e2-467b-ab47-2ddc2adcd643", routeValues, queryValues)
+        .then((versioningData: vsom.ClientVersioningData) => {
+            var url: string = versioningData.requestUrl;
+            var apiVersion: string = versioningData.apiVersion;
+            var serializationData = { requestTypeMetadata: TestInterfaces.TypeInfo.BuildReference, responseTypeMetadata: TestInterfaces.TypeInfo.TestFailures, responseIsCollection: false };
+            
+            this.restClient.getJson(url, apiVersion, null, serializationData, onResult);
+        })
+        .fail((error) => {
+            onResult(error, error.statusCode, null);
+        });
+    }
+
+    /**
+     * @param {string} project - Project ID or project name
+     * @param {number} testRunId
+     * @param onResult callback function with the resulting TestInterfaces.TestFailures
+     */
+    public queryFailureDetailsForTestRun(
+        project: string,
+        testRunId: number,
+        onResult: (err: any, statusCode: number, TestFailure: TestInterfaces.TestFailures) => void
+        ): void {
+
+        var routeValues: any = {
+            project: project
+        };
+
+        var queryValues: any = {
+            testRunId: testRunId,
+        };
+        
+        this.vsoClient.getVersioningData("3.0-preview.1", "Test", "aa4e770d-13e2-467b-ab47-2ddc2adcd643", routeValues, queryValues)
+        .then((versioningData: vsom.ClientVersioningData) => {
+            var url: string = versioningData.requestUrl;
+            var apiVersion: string = versioningData.apiVersion;
+            var serializationData = {  responseTypeMetadata: TestInterfaces.TypeInfo.TestFailures, responseIsCollection: false };
+            
+            this.restClient.getJson(url, apiVersion, null, serializationData, onResult);
         })
         .fail((error) => {
             onResult(error, error.statusCode, null);
@@ -2144,6 +2296,62 @@ export class QTestApi extends basem.QClientApiBase implements IQTestApi {
         });
 
         return <Q.Promise<TestInterfaces.TestPoint[]>>deferred.promise;
+    }
+    
+    /**
+    * @param {TestInterfaces.BuildReference} build
+    * @param {string} project - Project ID or project name
+    * @param {string} sourceWorkflow
+    * @param {boolean} includeFailureDetails
+    * @param {TestInterfaces.BuildReference} buildToCompare
+    */
+    public queryReportForBuild(
+        build: TestInterfaces.BuildReference, 
+        project: string, 
+        sourceWorkflow: string, 
+        includeFailureDetails: boolean, 
+        buildToCompare: TestInterfaces.BuildReference
+        ): Q.Promise<TestInterfaces.TestReport> {
+    
+        var deferred = Q.defer<TestInterfaces.TestReport>();
+
+        this.api.queryReportForBuild(build, project, sourceWorkflow, includeFailureDetails, buildToCompare, (err: any, statusCode: number, ReportForBuild: TestInterfaces.TestReport) => {
+            if(err) {
+                err.statusCode = statusCode;
+                deferred.reject(err);
+            }
+            else {
+                deferred.resolve(ReportForBuild);
+            }
+        });
+
+        return <Q.Promise<TestInterfaces.TestReport>>deferred.promise;
+    }
+    
+    /**
+    * @param {string} project - Project ID or project name
+    * @param {number} testRunId
+    * @param {boolean} includeFailureDetails
+    */
+    public queryReportForTestRun(
+        project: string, 
+        testRunId: number, 
+        includeFailureDetails: boolean
+        ): Q.Promise<TestInterfaces.TestReport> {
+    
+        var deferred = Q.defer<TestInterfaces.TestReport>();
+
+        this.api.queryReportForTestRun(project, testRunId, includeFailureDetails, (err: any, statusCode: number, ReportForBuild: TestInterfaces.TestReport) => {
+            if(err) {
+                err.statusCode = statusCode;
+                deferred.reject(err);
+            }
+            else {
+                deferred.resolve(ReportForBuild);
+            }
+        });
+
+        return <Q.Promise<TestInterfaces.TestReport>>deferred.promise;
     }
     
     /**
@@ -2812,6 +3020,58 @@ export class QTestApi extends basem.QClientApiBase implements IQTestApi {
         });
 
         return <Q.Promise<TestInterfaces.TestSuite[]>>deferred.promise;
+    }
+    
+    /**
+    * @param {TestInterfaces.BuildReference} build
+    * @param {string} project - Project ID or project name
+    * @param {string} sourceWorkflow
+    * @param {TestInterfaces.BuildReference} buildToCompare
+    */
+    public queryFailureDetailsForBuild(
+        build: TestInterfaces.BuildReference, 
+        project: string, 
+        sourceWorkflow: string, 
+        buildToCompare: TestInterfaces.BuildReference
+        ): Q.Promise<TestInterfaces.TestFailures> {
+    
+        var deferred = Q.defer<TestInterfaces.TestFailures>();
+
+        this.api.queryFailureDetailsForBuild(build, project, sourceWorkflow, buildToCompare, (err: any, statusCode: number, TestFailure: TestInterfaces.TestFailures) => {
+            if(err) {
+                err.statusCode = statusCode;
+                deferred.reject(err);
+            }
+            else {
+                deferred.resolve(TestFailure);
+            }
+        });
+
+        return <Q.Promise<TestInterfaces.TestFailures>>deferred.promise;
+    }
+    
+    /**
+    * @param {string} project - Project ID or project name
+    * @param {number} testRunId
+    */
+    public queryFailureDetailsForTestRun(
+        project: string, 
+        testRunId: number
+        ): Q.Promise<TestInterfaces.TestFailures> {
+    
+        var deferred = Q.defer<TestInterfaces.TestFailures>();
+
+        this.api.queryFailureDetailsForTestRun(project, testRunId, (err: any, statusCode: number, TestFailure: TestInterfaces.TestFailures) => {
+            if(err) {
+                err.statusCode = statusCode;
+                deferred.reject(err);
+            }
+            else {
+                deferred.resolve(TestFailure);
+            }
+        });
+
+        return <Q.Promise<TestInterfaces.TestFailures>>deferred.promise;
     }
     
     /**

--- a/api/TfvcApi.ts
+++ b/api/TfvcApi.ts
@@ -155,7 +155,7 @@ export class TfvcApi extends basem.ClientApiBase implements ITfvcApi {
             var apiVersion: string = versioningData.apiVersion;
             var serializationData = {  responseTypeMetadata: TfvcInterfaces.TypeInfo.TfvcBranch, responseIsCollection: true };
             
-            this.restClient.getJsonWrappedArray(url, apiVersion, null, serializationData, onResult);
+            this.restClient.getJson(url, apiVersion, null, serializationData, onResult);
         })
         .fail((error) => {
             onResult(error, error.statusCode, null);
@@ -195,7 +195,7 @@ export class TfvcApi extends basem.ClientApiBase implements ITfvcApi {
             var apiVersion: string = versioningData.apiVersion;
             var serializationData = {  responseTypeMetadata: TfvcInterfaces.TypeInfo.TfvcBranchRef, responseIsCollection: true };
             
-            this.restClient.getJsonWrappedArray(url, apiVersion, null, serializationData, onResult);
+            this.restClient.getJson(url, apiVersion, null, serializationData, onResult);
         })
         .fail((error) => {
             onResult(error, error.statusCode, null);
@@ -232,7 +232,7 @@ export class TfvcApi extends basem.ClientApiBase implements ITfvcApi {
             var apiVersion: string = versioningData.apiVersion;
             var serializationData = {  responseTypeMetadata: TfvcInterfaces.TypeInfo.TfvcChange, responseIsCollection: true };
             
-            this.restClient.getJsonWrappedArray(url, apiVersion, null, serializationData, onResult);
+            this.restClient.getJson(url, apiVersion, null, serializationData, onResult);
         })
         .fail((error) => {
             onResult(error, error.statusCode, null);
@@ -379,7 +379,7 @@ export class TfvcApi extends basem.ClientApiBase implements ITfvcApi {
             var apiVersion: string = versioningData.apiVersion;
             var serializationData = {  responseTypeMetadata: TfvcInterfaces.TypeInfo.TfvcChangesetRef, responseIsCollection: true };
             
-            this.restClient.getJsonWrappedArray(url, apiVersion, null, serializationData, onResult);
+            this.restClient.getJson(url, apiVersion, null, serializationData, onResult);
         })
         .fail((error) => {
             onResult(error, error.statusCode, null);
@@ -430,7 +430,7 @@ export class TfvcApi extends basem.ClientApiBase implements ITfvcApi {
             var apiVersion: string = versioningData.apiVersion;
             var serializationData = {  responseTypeMetadata: TfvcInterfaces.TypeInfo.AssociatedWorkItem, responseIsCollection: true };
             
-            this.restClient.getJsonWrappedArray(url, apiVersion, null, serializationData, onResult);
+            this.restClient.getJson(url, apiVersion, null, serializationData, onResult);
         })
         .fail((error) => {
             onResult(error, error.statusCode, null);
@@ -601,7 +601,7 @@ export class TfvcApi extends basem.ClientApiBase implements ITfvcApi {
             var apiVersion: string = versioningData.apiVersion;
             var serializationData = {  responseTypeMetadata: TfvcInterfaces.TypeInfo.TfvcItem, responseIsCollection: true };
             
-            this.restClient.getJsonWrappedArray(url, apiVersion, null, serializationData, onResult);
+            this.restClient.getJson(url, apiVersion, null, serializationData, onResult);
         })
         .fail((error) => {
             onResult(error, error.statusCode, null);
@@ -736,7 +736,7 @@ export class TfvcApi extends basem.ClientApiBase implements ITfvcApi {
             var apiVersion: string = versioningData.apiVersion;
             var serializationData = {  responseTypeMetadata: TfvcInterfaces.TypeInfo.TfvcItem, responseIsCollection: true };
             
-            this.restClient.getJsonWrappedArray(url, apiVersion, null, serializationData, onResult);
+            this.restClient.getJson(url, apiVersion, null, serializationData, onResult);
         })
         .fail((error) => {
             onResult(error, error.statusCode, null);
@@ -813,7 +813,7 @@ export class TfvcApi extends basem.ClientApiBase implements ITfvcApi {
             var apiVersion: string = versioningData.apiVersion;
             var serializationData = {  responseTypeMetadata: TfvcInterfaces.TypeInfo.TfvcLabelRef, responseIsCollection: true };
             
-            this.restClient.getJsonWrappedArray(url, apiVersion, null, serializationData, onResult);
+            this.restClient.getJson(url, apiVersion, null, serializationData, onResult);
         })
         .fail((error) => {
             onResult(error, error.statusCode, null);
@@ -873,7 +873,7 @@ export class TfvcApi extends basem.ClientApiBase implements ITfvcApi {
             var apiVersion: string = versioningData.apiVersion;
             var serializationData = {  responseTypeMetadata: TfvcInterfaces.TypeInfo.VersionControlProjectInfo, responseIsCollection: true };
             
-            this.restClient.getJsonWrappedArray(url, apiVersion, null, serializationData, onResult);
+            this.restClient.getJson(url, apiVersion, null, serializationData, onResult);
         })
         .fail((error) => {
             onResult(error, error.statusCode, null);
@@ -910,7 +910,7 @@ export class TfvcApi extends basem.ClientApiBase implements ITfvcApi {
             var apiVersion: string = versioningData.apiVersion;
             var serializationData = {  responseTypeMetadata: TfvcInterfaces.TypeInfo.TfvcChange, responseIsCollection: true };
             
-            this.restClient.getJsonWrappedArray(url, apiVersion, null, serializationData, onResult);
+            this.restClient.getJson(url, apiVersion, null, serializationData, onResult);
         })
         .fail((error) => {
             onResult(error, error.statusCode, null);
@@ -981,7 +981,7 @@ export class TfvcApi extends basem.ClientApiBase implements ITfvcApi {
             var apiVersion: string = versioningData.apiVersion;
             var serializationData = {  responseTypeMetadata: TfvcInterfaces.TypeInfo.TfvcShelvesetRef, responseIsCollection: true };
             
-            this.restClient.getJsonWrappedArray(url, apiVersion, null, serializationData, onResult);
+            this.restClient.getJson(url, apiVersion, null, serializationData, onResult);
         })
         .fail((error) => {
             onResult(error, error.statusCode, null);
@@ -1012,7 +1012,7 @@ export class TfvcApi extends basem.ClientApiBase implements ITfvcApi {
             var apiVersion: string = versioningData.apiVersion;
             var serializationData = {  responseTypeMetadata: TfvcInterfaces.TypeInfo.AssociatedWorkItem, responseIsCollection: true };
             
-            this.restClient.getJsonWrappedArray(url, apiVersion, null, serializationData, onResult);
+            this.restClient.getJson(url, apiVersion, null, serializationData, onResult);
         })
         .fail((error) => {
             onResult(error, error.statusCode, null);

--- a/api/WorkItemTrackingApi.ts
+++ b/api/WorkItemTrackingApi.ts
@@ -26,41 +26,41 @@ export interface IWorkItemTrackingApi extends basem.ClientApiBase {
     createAttachment(customHeaders: any, contentStream: NodeJS.ReadableStream, fileName: string, uploadType: string, onResult: (err: any, statusCode: number, attachment: WorkItemTrackingInterfaces.AttachmentReference) => void): void;
     getAttachmentContent(id: string, fileName: string, onResult: (err: any, statusCode: number, res: NodeJS.ReadableStream) => void): void;
     getAttachmentZip(id: string, fileName: string, onResult: (err: any, statusCode: number, res: NodeJS.ReadableStream) => void): void;
-    getRootNodes(project: string, depth: number, onResult: (err: any, statusCode: number, classificationNodes: WorkItemTrackingInterfaces.WorkItemClassificationNode[]) => void): void;
+    getRootNodes(project: string, depth: number, onResult: (err: any, statusCode: number, classificationNode: WorkItemTrackingInterfaces.WorkItemClassificationNode[]) => void): void;
     createOrUpdateClassificationNode(postedNode: WorkItemTrackingInterfaces.WorkItemClassificationNode, project: string, structureGroup: WorkItemTrackingInterfaces.TreeStructureGroup, path: string, onResult: (err: any, statusCode: number, classificationNode: WorkItemTrackingInterfaces.WorkItemClassificationNode) => void): void;
     deleteClassificationNode(project: string, structureGroup: WorkItemTrackingInterfaces.TreeStructureGroup, path: string, reclassifyId: number, onResult: (err: any, statusCode: number) => void): void;
     getClassificationNode(project: string, structureGroup: WorkItemTrackingInterfaces.TreeStructureGroup, path: string, depth: number, onResult: (err: any, statusCode: number, classificationNode: WorkItemTrackingInterfaces.WorkItemClassificationNode) => void): void;
     updateClassificationNode(postedNode: WorkItemTrackingInterfaces.WorkItemClassificationNode, project: string, structureGroup: WorkItemTrackingInterfaces.TreeStructureGroup, path: string, onResult: (err: any, statusCode: number, classificationNode: WorkItemTrackingInterfaces.WorkItemClassificationNode) => void): void;
     getField(field: string, onResult: (err: any, statusCode: number, field: WorkItemTrackingInterfaces.WorkItemField) => void): void;
-    getFields(onResult: (err: any, statusCode: number, fields: WorkItemTrackingInterfaces.WorkItemField[]) => void): void;
+    getFields(onResult: (err: any, statusCode: number, field: WorkItemTrackingInterfaces.WorkItemField[]) => void): void;
     getHistory(id: number, top: number, skip: number, onResult: (err: any, statusCode: number, history: WorkItemTrackingInterfaces.WorkItemHistory[]) => void): void;
     getHistoryById(id: number, revisionNumber: number, onResult: (err: any, statusCode: number, history: WorkItemTrackingInterfaces.WorkItemHistory) => void): void;
     createQuery(postedQuery: WorkItemTrackingInterfaces.QueryHierarchyItem, project: string, query: string, onResult: (err: any, statusCode: number, querie: WorkItemTrackingInterfaces.QueryHierarchyItem) => void): void;
     deleteQuery(project: string, query: string, onResult: (err: any, statusCode: number) => void): void;
-    getQueries(project: string, expand: WorkItemTrackingInterfaces.QueryExpand, depth: number, includeDeleted: boolean, onResult: (err: any, statusCode: number, queries: WorkItemTrackingInterfaces.QueryHierarchyItem[]) => void): void;
+    getQueries(project: string, expand: WorkItemTrackingInterfaces.QueryExpand, depth: number, includeDeleted: boolean, onResult: (err: any, statusCode: number, querie: WorkItemTrackingInterfaces.QueryHierarchyItem[]) => void): void;
     getQuery(project: string, query: string, expand: WorkItemTrackingInterfaces.QueryExpand, depth: number, includeDeleted: boolean, onResult: (err: any, statusCode: number, querie: WorkItemTrackingInterfaces.QueryHierarchyItem) => void): void;
     updateQuery(queryUpdate: WorkItemTrackingInterfaces.QueryHierarchyItem, project: string, query: string, undeleteDescendants: boolean, onResult: (err: any, statusCode: number, querie: WorkItemTrackingInterfaces.QueryHierarchyItem) => void): void;
     getRevision(id: number, revisionNumber: number, expand: WorkItemTrackingInterfaces.WorkItemExpand, onResult: (err: any, statusCode: number, revision: WorkItemTrackingInterfaces.WorkItem) => void): void;
-    getRevisions(id: number, top: number, skip: number, expand: WorkItemTrackingInterfaces.WorkItemExpand, onResult: (err: any, statusCode: number, revisions: WorkItemTrackingInterfaces.WorkItem[]) => void): void;
+    getRevisions(id: number, top: number, skip: number, expand: WorkItemTrackingInterfaces.WorkItemExpand, onResult: (err: any, statusCode: number, revision: WorkItemTrackingInterfaces.WorkItem[]) => void): void;
     evaluateRulesOnField(ruleEngineInput: WorkItemTrackingInterfaces.FieldsToEvaluate, onResult: (err: any, statusCode: number) => void): void;
     getUpdate(id: number, updateNumber: number, onResult: (err: any, statusCode: number, update: WorkItemTrackingInterfaces.WorkItemUpdate) => void): void;
-    getUpdates(id: number, top: number, skip: number, onResult: (err: any, statusCode: number, updates: WorkItemTrackingInterfaces.WorkItemUpdate[]) => void): void;
+    getUpdates(id: number, top: number, skip: number, onResult: (err: any, statusCode: number, update: WorkItemTrackingInterfaces.WorkItemUpdate[]) => void): void;
     queryByWiql(wiql: WorkItemTrackingInterfaces.Wiql, project: string, onResult: (err: any, statusCode: number, wiql: WorkItemTrackingInterfaces.WorkItemQueryResult) => void): void;
     queryById(id: string, project: string, onResult: (err: any, statusCode: number, wiql: WorkItemTrackingInterfaces.WorkItemQueryResult) => void): void;
     getReportingLinks(project: string, types: string[], watermark: number, onResult: (err: any, statusCode: number, workItemLink: WorkItemTrackingInterfaces.ReportingWorkItemLinksBatch) => void): void;
     getRelationType(relation: string, onResult: (err: any, statusCode: number, workItemRelationType: WorkItemTrackingInterfaces.WorkItemRelationType) => void): void;
-    getRelationTypes(onResult: (err: any, statusCode: number, workItemRelationTypes: WorkItemTrackingInterfaces.WorkItemRelationType[]) => void): void;
-    readReportingRevisionsGet(project: string, fields: string[], types: string[], watermark: number, onResult: (err: any, statusCode: number, workItemRevision: WorkItemTrackingInterfaces.ReportingWorkItemRevisionsBatch) => void): void;
+    getRelationTypes(onResult: (err: any, statusCode: number, workItemRelationType: WorkItemTrackingInterfaces.WorkItemRelationType[]) => void): void;
+    readReportingRevisionsGet(project: string, fields: string[], types: string[], watermark: number, includeIdentityRef: boolean, onResult: (err: any, statusCode: number, workItemRevision: WorkItemTrackingInterfaces.ReportingWorkItemRevisionsBatch) => void): void;
     readReportingRevisionsPost(filter: WorkItemTrackingInterfaces.ReportingWorkItemRevisionsFilter, project: string, watermark: number, onResult: (err: any, statusCode: number, workItemRevision: WorkItemTrackingInterfaces.ReportingWorkItemRevisionsBatch) => void): void;
     getWorkItem(id: number, fields: string[], asOf: Date, expand: WorkItemTrackingInterfaces.WorkItemExpand, onResult: (err: any, statusCode: number, workItem: WorkItemTrackingInterfaces.WorkItem) => void): void;
-    getWorkItems(ids: number[], fields: string[], asOf: Date, expand: WorkItemTrackingInterfaces.WorkItemExpand, onResult: (err: any, statusCode: number, workItems: WorkItemTrackingInterfaces.WorkItem[]) => void): void;
+    getWorkItems(ids: number[], fields: string[], asOf: Date, expand: WorkItemTrackingInterfaces.WorkItemExpand, onResult: (err: any, statusCode: number, workItem: WorkItemTrackingInterfaces.WorkItem[]) => void): void;
     updateWorkItem(customHeaders: any, document: VSSInterfaces.JsonPatchDocument, id: number, validateOnly: boolean, bypassRules: boolean, onResult: (err: any, statusCode: number, workItem: WorkItemTrackingInterfaces.WorkItem) => void): void;
     getWorkItemTemplate(project: string, type: string, fields: string, asOf: Date, expand: WorkItemTrackingInterfaces.WorkItemExpand, onResult: (err: any, statusCode: number, workItem: WorkItemTrackingInterfaces.WorkItem) => void): void;
     updateWorkItemTemplate(customHeaders: any, document: VSSInterfaces.JsonPatchDocument, project: string, type: string, validateOnly: boolean, bypassRules: boolean, onResult: (err: any, statusCode: number, workItem: WorkItemTrackingInterfaces.WorkItem) => void): void;
-    getWorkItemTypeCategories(project: string, onResult: (err: any, statusCode: number, workItemTypeCategories: WorkItemTrackingInterfaces.WorkItemTypeCategory[]) => void): void;
+    getWorkItemTypeCategories(project: string, onResult: (err: any, statusCode: number, workItemTypeCategorie: WorkItemTrackingInterfaces.WorkItemTypeCategory[]) => void): void;
     getWorkItemTypeCategory(project: string, category: string, onResult: (err: any, statusCode: number, workItemTypeCategorie: WorkItemTrackingInterfaces.WorkItemTypeCategory) => void): void;
     getWorkItemType(project: string, type: string, onResult: (err: any, statusCode: number, workItemType: WorkItemTrackingInterfaces.WorkItemType) => void): void;
-    getWorkItemTypes(project: string, onResult: (err: any, statusCode: number, workItemTypes: WorkItemTrackingInterfaces.WorkItemType[]) => void): void;
+    getWorkItemTypes(project: string, onResult: (err: any, statusCode: number, workItemType: WorkItemTrackingInterfaces.WorkItemType[]) => void): void;
     getDependentFields(project: string, type: string, field: string, onResult: (err: any, statusCode: number, workItemTypesField: WorkItemTrackingInterfaces.FieldDependentRule) => void): void;
     exportWorkItemTypeDefinition(project: string, type: string, exportGlobalLists: boolean, onResult: (err: any, statusCode: number, workItemTypeTemplate: WorkItemTrackingInterfaces.WorkItemTypeTemplate) => void): void;
     updateWorkItemTypeDefinition(updateModel: WorkItemTrackingInterfaces.WorkItemTypeTemplateUpdateModel, project: string, onResult: (err: any, statusCode: number, workItemTypeTemplate: WorkItemTrackingInterfaces.ProvisioningResult) => void): void;
@@ -90,7 +90,7 @@ export interface IQWorkItemTrackingApi extends basem.QClientApiBase {
     getReportingLinks(project?: string, types?: string[],  watermark?: number): Q.Promise<WorkItemTrackingInterfaces.ReportingWorkItemLinksBatch>;
     getRelationType( relation: string): Q.Promise<WorkItemTrackingInterfaces.WorkItemRelationType>;
     getRelationTypes(): Q.Promise<WorkItemTrackingInterfaces.WorkItemRelationType[]>;
-    readReportingRevisionsGet(project?: string, fields?: string[], types?: string[],  watermark?: number): Q.Promise<WorkItemTrackingInterfaces.ReportingWorkItemRevisionsBatch>;
+    readReportingRevisionsGet(project?: string, fields?: string[], types?: string[], watermark?: number,  includeIdentityRef?: boolean): Q.Promise<WorkItemTrackingInterfaces.ReportingWorkItemRevisionsBatch>;
     readReportingRevisionsPost(filter: WorkItemTrackingInterfaces.ReportingWorkItemRevisionsFilter, project?: string,  watermark?: number): Q.Promise<WorkItemTrackingInterfaces.ReportingWorkItemRevisionsBatch>;
     getWorkItem(id: number, fields?: string[], asOf?: Date,  expand?: WorkItemTrackingInterfaces.WorkItemExpand): Q.Promise<WorkItemTrackingInterfaces.WorkItem>;
     getWorkItems(ids: number[], fields?: string[], asOf?: Date,  expand?: WorkItemTrackingInterfaces.WorkItemExpand): Q.Promise<WorkItemTrackingInterfaces.WorkItem[]>;
@@ -228,7 +228,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
     public getRootNodes(
         project: string,
         depth: number,
-        onResult: (err: any, statusCode: number, classificationNodes: WorkItemTrackingInterfaces.WorkItemClassificationNode[]) => void
+        onResult: (err: any, statusCode: number, classificationNode: WorkItemTrackingInterfaces.WorkItemClassificationNode[]) => void
         ): void {
 
         var routeValues: any = {
@@ -245,7 +245,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
             var apiVersion: string = versioningData.apiVersion;
             var serializationData = {  responseTypeMetadata: WorkItemTrackingInterfaces.TypeInfo.WorkItemClassificationNode, responseIsCollection: true };
             
-            this.restClient.getJsonWrappedArray(url, apiVersion, null, serializationData, onResult);
+            this.restClient.getJson(url, apiVersion, null, serializationData, onResult);
         })
         .fail((error) => {
             onResult(error, error.statusCode, null);
@@ -426,7 +426,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
      * @param onResult callback function with the resulting WorkItemTrackingInterfaces.WorkItemField[]
      */
     public getFields(
-        onResult: (err: any, statusCode: number, fields: WorkItemTrackingInterfaces.WorkItemField[]) => void
+        onResult: (err: any, statusCode: number, field: WorkItemTrackingInterfaces.WorkItemField[]) => void
         ): void {
 
         var routeValues: any = {
@@ -438,7 +438,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
             var apiVersion: string = versioningData.apiVersion;
             var serializationData = {  responseTypeMetadata: WorkItemTrackingInterfaces.TypeInfo.WorkItemField, responseIsCollection: true };
             
-            this.restClient.getJsonWrappedArray(url, apiVersion, null, serializationData, onResult);
+            this.restClient.getJson(url, apiVersion, null, serializationData, onResult);
         })
         .fail((error) => {
             onResult(error, error.statusCode, null);
@@ -475,7 +475,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
             var apiVersion: string = versioningData.apiVersion;
             var serializationData = {  responseTypeMetadata: WorkItemTrackingInterfaces.TypeInfo.WorkItemHistory, responseIsCollection: true };
             
-            this.restClient.getJsonWrappedArray(url, apiVersion, null, serializationData, onResult);
+            this.restClient.getJson(url, apiVersion, null, serializationData, onResult);
         })
         .fail((error) => {
             onResult(error, error.statusCode, null);
@@ -589,7 +589,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
         expand: WorkItemTrackingInterfaces.QueryExpand,
         depth: number,
         includeDeleted: boolean,
-        onResult: (err: any, statusCode: number, queries: WorkItemTrackingInterfaces.QueryHierarchyItem[]) => void
+        onResult: (err: any, statusCode: number, querie: WorkItemTrackingInterfaces.QueryHierarchyItem[]) => void
         ): void {
 
         var routeValues: any = {
@@ -608,7 +608,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
             var apiVersion: string = versioningData.apiVersion;
             var serializationData = {  responseTypeMetadata: WorkItemTrackingInterfaces.TypeInfo.QueryHierarchyItem, responseIsCollection: true };
             
-            this.restClient.getJsonWrappedArray(url, apiVersion, null, serializationData, onResult);
+            this.restClient.getJson(url, apiVersion, null, serializationData, onResult);
         })
         .fail((error) => {
             onResult(error, error.statusCode, null);
@@ -746,7 +746,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
         top: number,
         skip: number,
         expand: WorkItemTrackingInterfaces.WorkItemExpand,
-        onResult: (err: any, statusCode: number, revisions: WorkItemTrackingInterfaces.WorkItem[]) => void
+        onResult: (err: any, statusCode: number, revision: WorkItemTrackingInterfaces.WorkItem[]) => void
         ): void {
 
         var routeValues: any = {
@@ -765,7 +765,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
             var apiVersion: string = versioningData.apiVersion;
             var serializationData = {  responseTypeMetadata: WorkItemTrackingInterfaces.TypeInfo.WorkItem, responseIsCollection: true };
             
-            this.restClient.getJsonWrappedArray(url, apiVersion, null, serializationData, onResult);
+            this.restClient.getJson(url, apiVersion, null, serializationData, onResult);
         })
         .fail((error) => {
             onResult(error, error.statusCode, null);
@@ -842,7 +842,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
         id: number,
         top: number,
         skip: number,
-        onResult: (err: any, statusCode: number, updates: WorkItemTrackingInterfaces.WorkItemUpdate[]) => void
+        onResult: (err: any, statusCode: number, update: WorkItemTrackingInterfaces.WorkItemUpdate[]) => void
         ): void {
 
         var routeValues: any = {
@@ -860,7 +860,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
             var apiVersion: string = versioningData.apiVersion;
             var serializationData = {  responseTypeMetadata: WorkItemTrackingInterfaces.TypeInfo.WorkItemUpdate, responseIsCollection: true };
             
-            this.restClient.getJsonWrappedArray(url, apiVersion, null, serializationData, onResult);
+            this.restClient.getJson(url, apiVersion, null, serializationData, onResult);
         })
         .fail((error) => {
             onResult(error, error.statusCode, null);
@@ -995,7 +995,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
      * @param onResult callback function with the resulting WorkItemTrackingInterfaces.WorkItemRelationType[]
      */
     public getRelationTypes(
-        onResult: (err: any, statusCode: number, workItemRelationTypes: WorkItemTrackingInterfaces.WorkItemRelationType[]) => void
+        onResult: (err: any, statusCode: number, workItemRelationType: WorkItemTrackingInterfaces.WorkItemRelationType[]) => void
         ): void {
 
         var routeValues: any = {
@@ -1007,7 +1007,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
             var apiVersion: string = versioningData.apiVersion;
             var serializationData = {  responseTypeMetadata: WorkItemTrackingInterfaces.TypeInfo.WorkItemRelationType, responseIsCollection: true };
             
-            this.restClient.getJsonWrappedArray(url, apiVersion, null, serializationData, onResult);
+            this.restClient.getJson(url, apiVersion, null, serializationData, onResult);
         })
         .fail((error) => {
             onResult(error, error.statusCode, null);
@@ -1019,6 +1019,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
      * @param {string[]} fields
      * @param {string[]} types
      * @param {number} watermark
+     * @param {boolean} includeIdentityRef
      * @param onResult callback function with the resulting WorkItemTrackingInterfaces.ReportingWorkItemRevisionsBatch
      */
     public readReportingRevisionsGet(
@@ -1026,6 +1027,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
         fields: string[],
         types: string[],
         watermark: number,
+        includeIdentityRef: boolean,
         onResult: (err: any, statusCode: number, workItemRevision: WorkItemTrackingInterfaces.ReportingWorkItemRevisionsBatch) => void
         ): void {
 
@@ -1037,6 +1039,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
             fields: fields && fields.join(","),
             types: types && types.join(","),
             watermark: watermark,
+            includeIdentityRef: includeIdentityRef,
         };
         
         this.vsoClient.getVersioningData("3.0-preview.1", "wit", "f828fe59-dd87-495d-a17c-7a8d6211ca6c", routeValues, queryValues)
@@ -1140,7 +1143,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
         fields: string[],
         asOf: Date,
         expand: WorkItemTrackingInterfaces.WorkItemExpand,
-        onResult: (err: any, statusCode: number, workItems: WorkItemTrackingInterfaces.WorkItem[]) => void
+        onResult: (err: any, statusCode: number, workItem: WorkItemTrackingInterfaces.WorkItem[]) => void
         ): void {
 
         var routeValues: any = {
@@ -1159,7 +1162,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
             var apiVersion: string = versioningData.apiVersion;
             var serializationData = {  responseTypeMetadata: WorkItemTrackingInterfaces.TypeInfo.WorkItem, responseIsCollection: true };
             
-            this.restClient.getJsonWrappedArray(url, apiVersion, null, serializationData, onResult);
+            this.restClient.getJson(url, apiVersion, null, serializationData, onResult);
         })
         .fail((error) => {
             onResult(error, error.statusCode, null);
@@ -1300,7 +1303,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
      */
     public getWorkItemTypeCategories(
         project: string,
-        onResult: (err: any, statusCode: number, workItemTypeCategories: WorkItemTrackingInterfaces.WorkItemTypeCategory[]) => void
+        onResult: (err: any, statusCode: number, workItemTypeCategorie: WorkItemTrackingInterfaces.WorkItemTypeCategory[]) => void
         ): void {
 
         var routeValues: any = {
@@ -1313,7 +1316,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
             var apiVersion: string = versioningData.apiVersion;
             var serializationData = {  responseTypeMetadata: WorkItemTrackingInterfaces.TypeInfo.WorkItemTypeCategory, responseIsCollection: true };
             
-            this.restClient.getJsonWrappedArray(url, apiVersion, null, serializationData, onResult);
+            this.restClient.getJson(url, apiVersion, null, serializationData, onResult);
         })
         .fail((error) => {
             onResult(error, error.statusCode, null);
@@ -1388,7 +1391,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
      */
     public getWorkItemTypes(
         project: string,
-        onResult: (err: any, statusCode: number, workItemTypes: WorkItemTrackingInterfaces.WorkItemType[]) => void
+        onResult: (err: any, statusCode: number, workItemType: WorkItemTrackingInterfaces.WorkItemType[]) => void
         ): void {
 
         var routeValues: any = {
@@ -1401,7 +1404,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
             var apiVersion: string = versioningData.apiVersion;
             var serializationData = {  responseTypeMetadata: WorkItemTrackingInterfaces.TypeInfo.WorkItemType, responseIsCollection: true };
             
-            this.restClient.getJsonWrappedArray(url, apiVersion, null, serializationData, onResult);
+            this.restClient.getJson(url, apiVersion, null, serializationData, onResult);
         })
         .fail((error) => {
             onResult(error, error.statusCode, null);
@@ -1560,13 +1563,13 @@ export class QWorkItemTrackingApi extends basem.QClientApiBase implements IQWork
     
         var deferred = Q.defer<WorkItemTrackingInterfaces.WorkItemClassificationNode[]>();
 
-        this.api.getRootNodes(project, depth, (err: any, statusCode: number, classificationNodes: WorkItemTrackingInterfaces.WorkItemClassificationNode[]) => {
+        this.api.getRootNodes(project, depth, (err: any, statusCode: number, classificationNode: WorkItemTrackingInterfaces.WorkItemClassificationNode[]) => {
             if(err) {
                 err.statusCode = statusCode;
                 deferred.reject(err);
             }
             else {
-                deferred.resolve(classificationNodes);
+                deferred.resolve(classificationNode);
             }
         });
 
@@ -1686,13 +1689,13 @@ export class QWorkItemTrackingApi extends basem.QClientApiBase implements IQWork
     
         var deferred = Q.defer<WorkItemTrackingInterfaces.WorkItemField[]>();
 
-        this.api.getFields((err: any, statusCode: number, fields: WorkItemTrackingInterfaces.WorkItemField[]) => {
+        this.api.getFields((err: any, statusCode: number, field: WorkItemTrackingInterfaces.WorkItemField[]) => {
             if(err) {
                 err.statusCode = statusCode;
                 deferred.reject(err);
             }
             else {
-                deferred.resolve(fields);
+                deferred.resolve(field);
             }
         });
 
@@ -1798,13 +1801,13 @@ export class QWorkItemTrackingApi extends basem.QClientApiBase implements IQWork
     
         var deferred = Q.defer<WorkItemTrackingInterfaces.QueryHierarchyItem[]>();
 
-        this.api.getQueries(project, expand, depth, includeDeleted, (err: any, statusCode: number, queries: WorkItemTrackingInterfaces.QueryHierarchyItem[]) => {
+        this.api.getQueries(project, expand, depth, includeDeleted, (err: any, statusCode: number, querie: WorkItemTrackingInterfaces.QueryHierarchyItem[]) => {
             if(err) {
                 err.statusCode = statusCode;
                 deferred.reject(err);
             }
             else {
-                deferred.resolve(queries);
+                deferred.resolve(querie);
             }
         });
 
@@ -1916,13 +1919,13 @@ export class QWorkItemTrackingApi extends basem.QClientApiBase implements IQWork
     
         var deferred = Q.defer<WorkItemTrackingInterfaces.WorkItem[]>();
 
-        this.api.getRevisions(id, top, skip, expand, (err: any, statusCode: number, revisions: WorkItemTrackingInterfaces.WorkItem[]) => {
+        this.api.getRevisions(id, top, skip, expand, (err: any, statusCode: number, revision: WorkItemTrackingInterfaces.WorkItem[]) => {
             if(err) {
                 err.statusCode = statusCode;
                 deferred.reject(err);
             }
             else {
-                deferred.resolve(revisions);
+                deferred.resolve(revision);
             }
         });
 
@@ -1970,13 +1973,13 @@ export class QWorkItemTrackingApi extends basem.QClientApiBase implements IQWork
     
         var deferred = Q.defer<WorkItemTrackingInterfaces.WorkItemUpdate[]>();
 
-        this.api.getUpdates(id, top, skip, (err: any, statusCode: number, updates: WorkItemTrackingInterfaces.WorkItemUpdate[]) => {
+        this.api.getUpdates(id, top, skip, (err: any, statusCode: number, update: WorkItemTrackingInterfaces.WorkItemUpdate[]) => {
             if(err) {
                 err.statusCode = statusCode;
                 deferred.reject(err);
             }
             else {
-                deferred.resolve(updates);
+                deferred.resolve(update);
             }
         });
 
@@ -2092,13 +2095,13 @@ export class QWorkItemTrackingApi extends basem.QClientApiBase implements IQWork
     
         var deferred = Q.defer<WorkItemTrackingInterfaces.WorkItemRelationType[]>();
 
-        this.api.getRelationTypes((err: any, statusCode: number, workItemRelationTypes: WorkItemTrackingInterfaces.WorkItemRelationType[]) => {
+        this.api.getRelationTypes((err: any, statusCode: number, workItemRelationType: WorkItemTrackingInterfaces.WorkItemRelationType[]) => {
             if(err) {
                 err.statusCode = statusCode;
                 deferred.reject(err);
             }
             else {
-                deferred.resolve(workItemRelationTypes);
+                deferred.resolve(workItemRelationType);
             }
         });
 
@@ -2110,17 +2113,19 @@ export class QWorkItemTrackingApi extends basem.QClientApiBase implements IQWork
     * @param {string[]} fields
     * @param {string[]} types
     * @param {number} watermark
+    * @param {boolean} includeIdentityRef
     */
     public readReportingRevisionsGet(
         project?: string, 
         fields?: string[], 
         types?: string[], 
-        watermark?: number
+        watermark?: number, 
+        includeIdentityRef?: boolean
         ): Q.Promise<WorkItemTrackingInterfaces.ReportingWorkItemRevisionsBatch> {
     
         var deferred = Q.defer<WorkItemTrackingInterfaces.ReportingWorkItemRevisionsBatch>();
 
-        this.api.readReportingRevisionsGet(project, fields, types, watermark, (err: any, statusCode: number, workItemRevision: WorkItemTrackingInterfaces.ReportingWorkItemRevisionsBatch) => {
+        this.api.readReportingRevisionsGet(project, fields, types, watermark, includeIdentityRef, (err: any, statusCode: number, workItemRevision: WorkItemTrackingInterfaces.ReportingWorkItemRevisionsBatch) => {
             if(err) {
                 err.statusCode = statusCode;
                 deferred.reject(err);
@@ -2206,13 +2211,13 @@ export class QWorkItemTrackingApi extends basem.QClientApiBase implements IQWork
     
         var deferred = Q.defer<WorkItemTrackingInterfaces.WorkItem[]>();
 
-        this.api.getWorkItems(ids, fields, asOf, expand, (err: any, statusCode: number, workItems: WorkItemTrackingInterfaces.WorkItem[]) => {
+        this.api.getWorkItems(ids, fields, asOf, expand, (err: any, statusCode: number, workItem: WorkItemTrackingInterfaces.WorkItem[]) => {
             if(err) {
                 err.statusCode = statusCode;
                 deferred.reject(err);
             }
             else {
-                deferred.resolve(workItems);
+                deferred.resolve(workItem);
             }
         });
 
@@ -2320,13 +2325,13 @@ export class QWorkItemTrackingApi extends basem.QClientApiBase implements IQWork
     
         var deferred = Q.defer<WorkItemTrackingInterfaces.WorkItemTypeCategory[]>();
 
-        this.api.getWorkItemTypeCategories(project, (err: any, statusCode: number, workItemTypeCategories: WorkItemTrackingInterfaces.WorkItemTypeCategory[]) => {
+        this.api.getWorkItemTypeCategories(project, (err: any, statusCode: number, workItemTypeCategorie: WorkItemTrackingInterfaces.WorkItemTypeCategory[]) => {
             if(err) {
                 err.statusCode = statusCode;
                 deferred.reject(err);
             }
             else {
-                deferred.resolve(workItemTypeCategories);
+                deferred.resolve(workItemTypeCategorie);
             }
         });
 
@@ -2394,13 +2399,13 @@ export class QWorkItemTrackingApi extends basem.QClientApiBase implements IQWork
     
         var deferred = Q.defer<WorkItemTrackingInterfaces.WorkItemType[]>();
 
-        this.api.getWorkItemTypes(project, (err: any, statusCode: number, workItemTypes: WorkItemTrackingInterfaces.WorkItemType[]) => {
+        this.api.getWorkItemTypes(project, (err: any, statusCode: number, workItemType: WorkItemTrackingInterfaces.WorkItemType[]) => {
             if(err) {
                 err.statusCode = statusCode;
                 deferred.reject(err);
             }
             else {
-                deferred.resolve(workItemTypes);
+                deferred.resolve(workItemType);
             }
         });
 

--- a/api/interfaces/TaskAgentInterfaces.ts
+++ b/api/interfaces/TaskAgentInterfaces.ts
@@ -311,6 +311,9 @@ export interface TaskAttachment {
     type: string;
 }
 
+export interface TaskChangeEvent {
+}
+
 export interface TaskDefinition {
     agentExecution: TaskExecution;
     author: string;
@@ -731,6 +734,9 @@ export var TypeInfo = {
     TaskAttachment: {
         fields: <any>null
     },
+    TaskChangeEvent: {
+        fields: <any>null
+    },
     TaskDefinition: {
         fields: <any>null
     },
@@ -1028,6 +1034,9 @@ TypeInfo.TaskAttachment.fields = {
     lastChangedOn: {
         isDate: true,
     },
+};
+
+TypeInfo.TaskChangeEvent.fields = {
 };
 
 TypeInfo.TaskDefinition.fields = {

--- a/api/interfaces/TestInterfaces.ts
+++ b/api/interfaces/TestInterfaces.ts
@@ -13,15 +13,15 @@
 import VSSInterfaces = require("../interfaces/common/VSSInterfaces");
 
 
-export interface AggregatedResultsByPivot {
+export interface AggregatedResultsByOutcome {
     count: number;
     duration: any;
-    pivot: string;
+    outcome: TestOutcome;
 }
 
 export interface AggregatedTestResults {
     duration: any;
-    resultsByPivot: AggregatedResultsByPivot[];
+    resultsByOutcome: AggregatedResultsByOutcome[];
     self: ShallowReference;
     totalTests: number;
 }
@@ -47,10 +47,15 @@ export interface BatchResponse {
 }
 
 export interface BuildConfiguration {
+    branchName: string;
+    buildDefinitionId: number;
     flavor: string;
     id: number;
+    number: string;
     platform: string;
     project: ShallowReference;
+    repositoryId: number;
+    sourceVersion: string;
     uri: string;
 }
 
@@ -60,6 +65,13 @@ export interface BuildCoverage {
     lastError: string;
     modules: ModuleCoverage[];
     state: string;
+}
+
+export interface BuildReference {
+    buildSystem: string;
+    id: number;
+    number: string;
+    uri: string;
 }
 
 /**
@@ -189,6 +201,11 @@ export interface DtlEnvironmentDetails {
     subscriptionName: string;
 }
 
+export interface FailingSince {
+    build: BuildReference;
+    date: Date;
+}
+
 export interface FunctionCoverage {
     class: string;
     name: string;
@@ -267,7 +284,6 @@ export interface ResultUpdateResponseModel {
 }
 
 export interface RunCreateModel {
-    additionalTestFields: CustomTestField[];
     automated: boolean;
     build: ShallowReference;
     buildDropLocation: string;
@@ -277,6 +293,7 @@ export interface RunCreateModel {
     completeDate: string;
     configurationIds: number[];
     controller: string;
+    customTestFields: CustomTestField[];
     dtlAutEnvironment: ShallowReference;
     dtlTestEnvironment: ShallowReference;
     dueDate: string;
@@ -291,6 +308,7 @@ export interface RunCreateModel {
     releaseEnvironmentUri: string;
     releaseUri: string;
     runTimeout: any;
+    sourceWorkflow: string;
     startDate: string;
     state: string;
     testConfigurationsMapping: string;
@@ -395,7 +413,6 @@ export interface TestAttachmentRequestModel {
 }
 
 export interface TestCaseResult {
-    additionalFields: CustomTestField[];
     afnStripId: number;
     area: ShallowReference;
     associatedBugs: ShallowReference[];
@@ -410,8 +427,10 @@ export interface TestCaseResult {
     computerName: string;
     configuration: ShallowReference;
     createdDate: Date;
+    customFields: CustomTestField[];
     durationInMs: number;
     errorMessage: string;
+    failingSince: FailingSince;
     failureType: string;
     id: number;
     iterationDetails: TestIterationDetailsModel[];
@@ -472,12 +491,12 @@ export interface TestCaseResultIdentifier {
 }
 
 export interface TestCaseResultUpdateModel {
-    additionalFields: CustomTestField[];
     associatedWorkItems: number[];
     automatedTestTypeId: string;
     comment: string;
     completedDate: string;
     computerName: string;
+    customFields: CustomTestField[];
     durationInMs: string;
     errorMessage: string;
     failureType: string;
@@ -497,17 +516,17 @@ export interface TestEnvironment {
     environmentName: string;
 }
 
-export interface TestInsightDetails {
+export interface TestFailureDetails {
     count: number;
-    previousBuild: ShallowReference;
+    previousBuild: BuildReference;
     self: ShallowReference;
     testResults: ShallowReference[];
 }
 
-export interface TestInsights {
-    existingFailures: TestInsightDetails;
-    fixedTests: TestInsightDetails;
-    newFailures: TestInsightDetails;
+export interface TestFailures {
+    existingFailures: TestFailureDetails;
+    fixedTests: TestFailureDetails;
+    newFailures: TestFailureDetails;
     self: ShallowReference;
 }
 
@@ -541,6 +560,66 @@ export interface TestMessageLogDetails {
      * Message of the resource
      */
     message: string;
+}
+
+export enum TestOutcome {
+    /**
+     * Only used during an update to preserve the existing value.
+     */
+    Unspecified = 0,
+    /**
+     * Test has not been completed, or the test type does not report pass/failure.
+     */
+    None = 1,
+    /**
+     * Test was executed w/o any issues.
+     */
+    Passed = 2,
+    /**
+     * Test was executed, but there were issues. Issues may involve exceptions or failed assertions.
+     */
+    Failed = 3,
+    /**
+     * Test has completed, but we can't say if it passed or failed. May be used for aborted tests...
+     */
+    Inconclusive = 4,
+    /**
+     * The test timed out
+     */
+    Timeout = 5,
+    /**
+     * Test was aborted. This was not caused by a user gesture, but rather by a framework decision.
+     */
+    Aborted = 6,
+    /**
+     * Test had it chance for been executed but was not, as ITestElement.IsRunnable == false.
+     */
+    Blocked = 7,
+    /**
+     * Test was not executed. This was caused by a user gesture - e.g. user hit stop button.
+     */
+    NotExecuted = 8,
+    /**
+     * To be used by Run level results. This is not a failure.
+     */
+    Warning = 9,
+    /**
+     * There was a system error while we were trying to execute a test.
+     */
+    Error = 10,
+    /**
+     * Test is Not Applicable for execution.
+     */
+    NotApplicable = 11,
+    /**
+     * Test is paused.
+     */
+    Paused = 12,
+    /**
+     * Test is currently executing. Added this for TCM charts
+     */
+    InProgress = 13,
+    MaxValue = 13,
 }
 
 export interface TestPlan {
@@ -598,10 +677,10 @@ export interface TestPoint {
 
 export interface TestReport {
     aggregatedResults: AggregatedTestResults;
-    build: ShallowReference;
+    build: BuildReference;
     self: ShallowReference;
     teamProject: ShallowReference;
-    testInsights: TestInsights;
+    testFailures: TestFailures;
 }
 
 export interface TestResolutionState {
@@ -611,7 +690,6 @@ export interface TestResolutionState {
 }
 
 export interface TestResultCreateModel {
-    additionalFields: CustomTestField[];
     area: ShallowReference;
     associatedWorkItems: number[];
     automatedTestId: string;
@@ -623,6 +701,7 @@ export interface TestResultCreateModel {
     completedDate: string;
     computerName: string;
     configuration: ShallowReference;
+    customFields: CustomTestField[];
     durationInMs: string;
     errorMessage: string;
     failureType: string;
@@ -657,13 +736,13 @@ export interface TestResultParameterModel {
 }
 
 export interface TestRun {
-    additionalFields: CustomTestField[];
     build: ShallowReference;
     buildConfiguration: BuildConfiguration;
     comment: string;
     completedDate: Date;
     controller: string;
     createdDate: Date;
+    customFields: CustomTestField[];
     dropLocation: string;
     dtlAutEnvironment: ShallowReference;
     dtlEnvironment: ShallowReference;
@@ -821,7 +900,7 @@ export interface WorkItemReference {
 }
 
 export var TypeInfo = {
-    AggregatedResultsByPivot: {
+    AggregatedResultsByOutcome: {
         fields: <any>null
     },
     AggregatedTestResults: {
@@ -849,6 +928,9 @@ export var TypeInfo = {
         fields: <any>null
     },
     BuildCoverage: {
+        fields: <any>null
+    },
+    BuildReference: {
         fields: <any>null
     },
     CodeCoverageData: {
@@ -896,6 +978,9 @@ export var TypeInfo = {
         }
     },
     DtlEnvironmentDetails: {
+        fields: <any>null
+    },
+    FailingSince: {
         fields: <any>null
     },
     FunctionCoverage: {
@@ -989,10 +1074,10 @@ export var TypeInfo = {
     TestEnvironment: {
         fields: <any>null
     },
-    TestInsightDetails: {
+    TestFailureDetails: {
         fields: <any>null
     },
-    TestInsights: {
+    TestFailures: {
         fields: <any>null
     },
     TestIterationDetailsModel: {
@@ -1000,6 +1085,25 @@ export var TypeInfo = {
     },
     TestMessageLogDetails: {
         fields: <any>null
+    },
+    TestOutcome: {
+        enumValues: {
+            "unspecified": 0,
+            "none": 1,
+            "passed": 2,
+            "failed": 3,
+            "inconclusive": 4,
+            "timeout": 5,
+            "aborted": 6,
+            "blocked": 7,
+            "notExecuted": 8,
+            "warning": 9,
+            "error": 10,
+            "notApplicable": 11,
+            "paused": 12,
+            "inProgress": 13,
+            "maxValue": 13,
+        }
     },
     TestPlan: {
         fields: <any>null
@@ -1069,13 +1173,16 @@ export var TypeInfo = {
     },
 };
 
-TypeInfo.AggregatedResultsByPivot.fields = {
+TypeInfo.AggregatedResultsByOutcome.fields = {
+    outcome: {
+        enumType: TypeInfo.TestOutcome
+    },
 };
 
 TypeInfo.AggregatedTestResults.fields = {
-    resultsByPivot: {
+    resultsByOutcome: {
         isArray: true,
-        typeInfo: TypeInfo.AggregatedResultsByPivot
+        typeInfo: TypeInfo.AggregatedResultsByOutcome
     },
     self: {
         typeInfo: TypeInfo.ShallowReference
@@ -1103,6 +1210,9 @@ TypeInfo.BuildCoverage.fields = {
         isArray: true,
         typeInfo: TypeInfo.ModuleCoverage
     },
+};
+
+TypeInfo.BuildReference.fields = {
 };
 
 TypeInfo.CodeCoverageData.fields = {
@@ -1144,6 +1254,15 @@ TypeInfo.CustomTestFieldDefinition.fields = {
 };
 
 TypeInfo.DtlEnvironmentDetails.fields = {
+};
+
+TypeInfo.FailingSince.fields = {
+    build: {
+        typeInfo: TypeInfo.BuildReference
+    },
+    date: {
+        isDate: true,
+    },
 };
 
 TypeInfo.FunctionCoverage.fields = {
@@ -1233,12 +1352,12 @@ TypeInfo.ResultUpdateResponseModel.fields = {
 };
 
 TypeInfo.RunCreateModel.fields = {
-    additionalTestFields: {
-        isArray: true,
-        typeInfo: TypeInfo.CustomTestField
-    },
     build: {
         typeInfo: TypeInfo.ShallowReference
+    },
+    customTestFields: {
+        isArray: true,
+        typeInfo: TypeInfo.CustomTestField
     },
     dtlAutEnvironment: {
         typeInfo: TypeInfo.ShallowReference
@@ -1338,10 +1457,6 @@ TypeInfo.TestAttachmentRequestModel.fields = {
 };
 
 TypeInfo.TestCaseResult.fields = {
-    additionalFields: {
-        isArray: true,
-        typeInfo: TypeInfo.CustomTestField
-    },
     area: {
         typeInfo: TypeInfo.ShallowReference
     },
@@ -1360,6 +1475,13 @@ TypeInfo.TestCaseResult.fields = {
     },
     createdDate: {
         isDate: true,
+    },
+    customFields: {
+        isArray: true,
+        typeInfo: TypeInfo.CustomTestField
+    },
+    failingSince: {
+        typeInfo: TypeInfo.FailingSince
     },
     iterationDetails: {
         isArray: true,
@@ -1413,7 +1535,7 @@ TypeInfo.TestCaseResultIdentifier.fields = {
 };
 
 TypeInfo.TestCaseResultUpdateModel.fields = {
-    additionalFields: {
+    customFields: {
         isArray: true,
         typeInfo: TypeInfo.CustomTestField
     },
@@ -1431,9 +1553,9 @@ TypeInfo.TestCaseResultUpdateModel.fields = {
 TypeInfo.TestEnvironment.fields = {
 };
 
-TypeInfo.TestInsightDetails.fields = {
+TypeInfo.TestFailureDetails.fields = {
     previousBuild: {
-        typeInfo: TypeInfo.ShallowReference
+        typeInfo: TypeInfo.BuildReference
     },
     self: {
         typeInfo: TypeInfo.ShallowReference
@@ -1444,15 +1566,15 @@ TypeInfo.TestInsightDetails.fields = {
     },
 };
 
-TypeInfo.TestInsights.fields = {
+TypeInfo.TestFailures.fields = {
     existingFailures: {
-        typeInfo: TypeInfo.TestInsightDetails
+        typeInfo: TypeInfo.TestFailureDetails
     },
     fixedTests: {
-        typeInfo: TypeInfo.TestInsightDetails
+        typeInfo: TypeInfo.TestFailureDetails
     },
     newFailures: {
-        typeInfo: TypeInfo.TestInsightDetails
+        typeInfo: TypeInfo.TestFailureDetails
     },
     self: {
         typeInfo: TypeInfo.ShallowReference
@@ -1573,7 +1695,7 @@ TypeInfo.TestReport.fields = {
         typeInfo: TypeInfo.AggregatedTestResults
     },
     build: {
-        typeInfo: TypeInfo.ShallowReference
+        typeInfo: TypeInfo.BuildReference
     },
     self: {
         typeInfo: TypeInfo.ShallowReference
@@ -1581,8 +1703,8 @@ TypeInfo.TestReport.fields = {
     teamProject: {
         typeInfo: TypeInfo.ShallowReference
     },
-    testInsights: {
-        typeInfo: TypeInfo.TestInsights
+    testFailures: {
+        typeInfo: TypeInfo.TestFailures
     },
 };
 
@@ -1593,15 +1715,15 @@ TypeInfo.TestResolutionState.fields = {
 };
 
 TypeInfo.TestResultCreateModel.fields = {
-    additionalFields: {
-        isArray: true,
-        typeInfo: TypeInfo.CustomTestField
-    },
     area: {
         typeInfo: TypeInfo.ShallowReference
     },
     configuration: {
         typeInfo: TypeInfo.ShallowReference
+    },
+    customFields: {
+        isArray: true,
+        typeInfo: TypeInfo.CustomTestField
     },
     owner: {
         typeInfo: VSSInterfaces.TypeInfo.IdentityRef
@@ -1630,10 +1752,6 @@ TypeInfo.TestResultParameterModel.fields = {
 };
 
 TypeInfo.TestRun.fields = {
-    additionalFields: {
-        isArray: true,
-        typeInfo: TypeInfo.CustomTestField
-    },
     build: {
         typeInfo: TypeInfo.ShallowReference
     },
@@ -1645,6 +1763,10 @@ TypeInfo.TestRun.fields = {
     },
     createdDate: {
         isDate: true,
+    },
+    customFields: {
+        isArray: true,
+        typeInfo: TypeInfo.CustomTestField
     },
     dtlAutEnvironment: {
         typeInfo: TypeInfo.ShallowReference

--- a/api/interfaces/WorkItemTrackingInterfaces.ts
+++ b/api/interfaces/WorkItemTrackingInterfaces.ts
@@ -149,6 +149,7 @@ export interface ReportingWorkItemRevisionsBatch extends StreamedBatch<WorkItem>
 
 export interface ReportingWorkItemRevisionsFilter {
     fields: string[];
+    includeIdentityRef: boolean;
     types: string[];
 }
 

--- a/api/interfaces/common/VsoBaseInterfaces.ts
+++ b/api/interfaces/common/VsoBaseInterfaces.ts
@@ -78,12 +78,9 @@ export interface IRestClient {
     baseUrl: string;
     httpClient: IHttpClient;
     getJson(relativeUrl: string, apiVersion: string, customHeaders: IHeaders, serializationData: Serialization.SerializationData, onResult: (err: any, statusCode: number, obj: any) => void): void;
-    getJsonWrappedArray(relativeUrl: string, apiVersion: string, customHeaders: IHeaders, serializationData: Serialization.SerializationData, onResult: (err: any, statusCode: number, obj: any) => void): void;
     options(requestUrl: string, onResult: (err: any, statusCode: number, obj: any) => void): void;
     create(relativeUrl: string, apiVersion: string, resources: any, customHeaders: IHeaders, serializationData: Serialization.SerializationData, onResult: (err: any, statusCode: number, obj: any) => void): void;
-    createJsonWrappedArray(relativeUrl: string, apiVersion: string, resources: any[], customHeaders: IHeaders, serializationData: Serialization.SerializationData, onResult: (err: any, statusCode: number, obj: any) => void): void;
     update(relativeUrl: string, apiVersion: string, resources: any, customHeaders: IHeaders, serializationData: Serialization.SerializationData, onResult: (err: any, statusCode: number, obj: any) => void): void;
-    updateJsonWrappedArray(relativeUrl: string, apiVersion: string, resources: any[], customHeaders: IHeaders, serializationData: Serialization.SerializationData, onResult: (err: any, statusCode: number, obj: any) => void): void;
     uploadFile(verb: string, relativeUrl: string, apiVersion: string, filePath: string, customHeaders: IHeaders, serializationData: Serialization.SerializationData, onResult: (err: any, statusCode: number, obj: any) => void): void;
     uploadStream(verb: string, relativeUrl: string, apiVersion: string, contentStream: NodeJS.ReadableStream, customHeaders: IHeaders, serializationData: Serialization.SerializationData, onResult: (err: any, statusCode: number, obj: any) => void): void;
     replace(relativeUrl: string, apiVersion: string, resources: any, customHeaders: IHeaders, serializationData: Serialization.SerializationData, onResult: (err: any, statusCode: number, obj: any) => void): void;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vso-node-api",
   "description": "Node client for Visual Studio Online/TFS REST APIs",
-  "version": "0.3.4",
+  "version": "0.4.0",
   "main": "./WebApi.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The methods in RestClient.ts that handled JsonWrappedArrays are no longer necessary because the generator will use VSSJsonCollectionWrappers whenever the controllers do. They actually caused problems in the generator logic because sometimes arrays that are taken as body parameters or returned are NOT wrapped up in that {count:number, value:T} form. This caused a 400, for example, on the previous version of the generated TestApi.addTestResultsToTestRun method.

Also updated the clients to the newest version in VSO.

Bumped version to 0.4.0